### PR TITLE
feat(T0010-T0016): 规则引擎 + 数据库层

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,0 +1,49 @@
+import { Tabs } from 'expo-router';
+import { BookOpen, Compass, Settings } from 'lucide-react-native';
+import { useColorScheme } from 'react-native';
+
+const ACTIVE_COLOR = '#E8735A';
+const INACTIVE_COLOR = '#999';
+
+export default function TabLayout() {
+  const scheme = useColorScheme();
+  const bg = scheme === 'dark' ? '#1A1A1A' : '#FFFFFF';
+
+  return (
+    <Tabs
+      screenOptions={{
+        tabBarActiveTintColor: ACTIVE_COLOR,
+        tabBarInactiveTintColor: INACTIVE_COLOR,
+        tabBarStyle: { backgroundColor: bg, borderTopWidth: 0.5, borderTopColor: '#E0E0E0' },
+        headerStyle: { backgroundColor: bg },
+        headerTintColor: scheme === 'dark' ? '#FFF' : '#333',
+        headerShadowVisible: false,
+      }}
+    >
+      <Tabs.Screen
+        name="index"
+        options={{
+          title: '书架',
+          tabBarIcon: ({ color, size }) => <BookOpen size={size} color={color} />,
+          headerTitle: '书架',
+        }}
+      />
+      <Tabs.Screen
+        name="explore"
+        options={{
+          title: '发现',
+          tabBarIcon: ({ color, size }) => <Compass size={size} color={color} />,
+          headerTitle: '发现',
+        }}
+      />
+      <Tabs.Screen
+        name="settings"
+        options={{
+          title: '设置',
+          tabBarIcon: ({ color, size }) => <Settings size={size} color={color} />,
+          headerTitle: '设置',
+        }}
+      />
+    </Tabs>
+  );
+}

--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -1,0 +1,164 @@
+/**
+ * 发现页面 — 通过书源 exploreUrl 规则抓取分类内容
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+  View, Text, FlatList, Pressable, StyleSheet, useColorScheme, ActivityIndicator,
+} from 'react-native';
+import { BookSourceDao } from '@/data/dao/BookSourceDao';
+import { BookSource } from '@/data/models/BookSource';
+import { AnalyzeUrl } from '@/core/network/AnalyzeUrl';
+import { httpFetch } from '@/core/network/HttpClient';
+import { AnalyzeRule } from '@/core/ruleEngine/AnalyzeRule';
+import { router } from 'expo-router';
+
+interface ExploreItem {
+  name: string;
+  bookUrl: string;
+  coverUrl?: string;
+  author?: string;
+  kind?: string;
+}
+
+export default function ExploreScreen() {
+  const isDark = useColorScheme() === 'dark';
+  const colors = isDark ? DARK : LIGHT;
+
+  const [sources, setSources] = useState<BookSource[]>([]);
+  const [selected, setSelected] = useState<BookSource | null>(null);
+  const [items, setItems] = useState<ExploreItem[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    BookSourceDao.getEnabled().then((all) => {
+      const withExplore = all.filter((s) => s.exploreUrl && s.enabledExplore);
+      setSources(withExplore);
+      if (withExplore.length) setSelected(withExplore[0]);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!selected) return;
+    setLoading(true);
+    setItems([]);
+    fetchExplore(selected)
+      .then(setItems)
+      .finally(() => setLoading(false));
+  }, [selected]);
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.bg }]}>
+      {/* 书源选择栏 */}
+      <FlatList
+        horizontal
+        data={sources}
+        keyExtractor={(s) => s.bookSourceUrl}
+        style={[styles.sourceBar, { borderBottomColor: colors.border }]}
+        showsHorizontalScrollIndicator={false}
+        renderItem={({ item }) => (
+          <Pressable
+            style={[
+              styles.sourceTab,
+              selected?.bookSourceUrl === item.bookSourceUrl && styles.sourceTabActive,
+            ]}
+            onPress={() => setSelected(item)}
+          >
+            <Text
+              style={[
+                styles.sourceTabText,
+                { color: selected?.bookSourceUrl === item.bookSourceUrl ? '#E8735A' : colors.textSecondary },
+              ]}
+            >
+              {item.bookSourceName}
+            </Text>
+          </Pressable>
+        )}
+      />
+
+      {loading ? (
+        <View style={styles.center}>
+          <ActivityIndicator color="#E8735A" />
+        </View>
+      ) : items.length === 0 && !loading ? (
+        <View style={styles.center}>
+          <Text style={{ color: colors.textSecondary }}>
+            {sources.length === 0 ? '请先添加支持发现的书源' : '暂无内容'}
+          </Text>
+        </View>
+      ) : (
+        <FlatList
+          data={items}
+          keyExtractor={(item) => item.bookUrl}
+          numColumns={3}
+          contentContainerStyle={styles.list}
+          renderItem={({ item }) => (
+            <Pressable
+              style={styles.exploreItem}
+              onPress={() => router.push(`/book/${encodeURIComponent(item.bookUrl)}`)}
+            >
+              <View style={[styles.exploreCover, { backgroundColor: colors.placeholder }]}>
+                <Text style={styles.exploreCoverText} numberOfLines={3}>{item.name}</Text>
+              </View>
+              <Text style={[styles.exploreTitle, { color: colors.text }]} numberOfLines={2}>
+                {item.name}
+              </Text>
+              {item.author && (
+                <Text style={[styles.exploreAuthor, { color: colors.textSecondary }]} numberOfLines={1}>
+                  {item.author}
+                </Text>
+              )}
+            </Pressable>
+          )}
+        />
+      )}
+    </View>
+  );
+}
+
+async function fetchExplore(source: BookSource): Promise<ExploreItem[]> {
+  if (!source.exploreUrl || !source.ruleExplore) return [];
+  try {
+    const parsed = new AnalyzeUrl(source.exploreUrl, { baseUrl: source.bookSourceUrl }).parse();
+    const resp = await httpFetch({ ...parsed, sourceHeader: source.header });
+    const analyzer = new AnalyzeRule(resp.text, resp.url);
+    const rule = source.ruleExplore;
+    if (!rule.bookList) return [];
+    const items = analyzer.getStringList(rule.bookList);
+    return items.map((html) => {
+      const a = new AnalyzeRule(html, resp.url);
+      return {
+        name: rule.name ? a.getString(rule.name) : '',
+        bookUrl: rule.bookUrl ? a.getString(rule.bookUrl) : '',
+        coverUrl: rule.coverUrl ? a.getString(rule.coverUrl) : undefined,
+        author: rule.author ? a.getString(rule.author) : undefined,
+        kind: rule.kind ? a.getString(rule.kind) : undefined,
+      };
+    }).filter((i) => i.name && i.bookUrl);
+  } catch {
+    return [];
+  }
+}
+
+const LIGHT = { bg: '#F8F5F0', text: '#222', textSecondary: '#888', border: '#EBEBEB', placeholder: '#E0D8D0' };
+const DARK = { bg: '#1A1A1A', text: '#EEE', textSecondary: '#777', border: '#2E2E2E', placeholder: '#2E2E2E' };
+
+const ITEM_W = (require('react-native').Dimensions.get('window').width - 32) / 3;
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  sourceBar: { maxHeight: 44, borderBottomWidth: 0.5 },
+  sourceTab: { paddingHorizontal: 14, paddingVertical: 10 },
+  sourceTabActive: { borderBottomWidth: 2, borderBottomColor: '#E8735A' },
+  sourceTabText: { fontSize: 13, fontWeight: '500' },
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  list: { padding: 8, gap: 8 },
+  exploreItem: { width: ITEM_W, margin: 4 },
+  exploreCover: {
+    width: ITEM_W, height: ITEM_W * 1.33, borderRadius: 4,
+    alignItems: 'center', justifyContent: 'center', padding: 8,
+  },
+  exploreCoverText: { fontSize: 13, fontWeight: '600', color: '#666', textAlign: 'center' },
+  exploreTitle: { fontSize: 13, marginTop: 4 },
+  exploreAuthor: { fontSize: 11 },
+});

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,0 +1,194 @@
+/**
+ * 书架主页
+ * T0050 — BookshelfScreen
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  View, Text, FlatList, Pressable, StyleSheet,
+  useColorScheme, RefreshControl, Alert,
+} from 'react-native';
+import { router } from 'expo-router';
+import { BookDao } from '@/data/dao/BookDao';
+import { BookGroup, DEFAULT_GROUPS } from '@/data/models/BookGroup';
+import { BookGroupDao } from '@/data/dao/BookGroupDao';
+import { Book } from '@/data/models/Book';
+import { BookCard } from '@/components/bookshelf/BookCard';
+import { LayoutGrid, List, Plus } from 'lucide-react-native';
+
+type ViewMode = 'grid' | 'list';
+
+export default function BookshelfScreen() {
+  const scheme = useColorScheme();
+  const isDark = scheme === 'dark';
+  const colors = isDark ? DARK : LIGHT;
+
+  const [books, setBooks] = useState<Book[]>([]);
+  const [groups, setGroups] = useState<BookGroup[]>(DEFAULT_GROUPS);
+  const [selectedGroup, setSelectedGroup] = useState<number>(-1);
+  const [viewMode, setViewMode] = useState<ViewMode>('grid');
+  const [refreshing, setRefreshing] = useState(false);
+
+  const loadBooks = useCallback(async () => {
+    const result = await BookDao.getByGroup(selectedGroup);
+    setBooks(result);
+  }, [selectedGroup]);
+
+  const loadGroups = useCallback(async () => {
+    try {
+      const dbGroups = await BookGroupDao.getAll();
+      setGroups(dbGroups.length ? dbGroups : DEFAULT_GROUPS);
+    } catch {
+      setGroups(DEFAULT_GROUPS);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadGroups();
+  }, [loadGroups]);
+
+  useEffect(() => {
+    loadBooks();
+  }, [loadBooks]);
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    await loadBooks();
+    setRefreshing(false);
+  };
+
+  const numColumns = viewMode === 'grid' ? 3 : 1;
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.bg }]}>
+      {/* 分组标签栏 */}
+      <FlatList
+        horizontal
+        data={groups.filter((g) => g.show)}
+        keyExtractor={(g) => String(g.groupId)}
+        style={[styles.groupBar, { borderBottomColor: colors.border }]}
+        showsHorizontalScrollIndicator={false}
+        renderItem={({ item }) => (
+          <Pressable
+            style={[
+              styles.groupTab,
+              selectedGroup === item.groupId && { borderBottomColor: '#E8735A', borderBottomWidth: 2 },
+            ]}
+            onPress={() => setSelectedGroup(item.groupId)}
+          >
+            <Text
+              style={[
+                styles.groupTabText,
+                { color: selectedGroup === item.groupId ? '#E8735A' : colors.textSecondary },
+              ]}
+            >
+              {item.groupName}
+            </Text>
+          </Pressable>
+        )}
+      />
+
+      {/* 工具栏 */}
+      <View style={[styles.toolbar, { borderBottomColor: colors.border }]}>
+        <Text style={[styles.countText, { color: colors.textSecondary }]}>
+          {books.length} 本
+        </Text>
+        <View style={styles.toolbarRight}>
+          <Pressable
+            style={styles.iconBtn}
+            onPress={() => setViewMode(viewMode === 'grid' ? 'list' : 'grid')}
+          >
+            {viewMode === 'grid'
+              ? <List size={20} color={colors.textSecondary} />
+              : <LayoutGrid size={20} color={colors.textSecondary} />}
+          </Pressable>
+          <Pressable
+            style={styles.iconBtn}
+            onPress={() => router.push('/booksource')}
+          >
+            <Plus size={20} color={colors.textSecondary} />
+          </Pressable>
+        </View>
+      </View>
+
+      {/* 书籍列表 */}
+      {books.length === 0 ? (
+        <EmptyShelf colors={colors} />
+      ) : (
+        <FlatList
+          key={viewMode}
+          data={books}
+          numColumns={numColumns}
+          keyExtractor={(b) => b.bookUrl}
+          contentContainerStyle={styles.list}
+          refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+          renderItem={({ item }) => (
+            <BookCard
+              book={item}
+              mode={viewMode}
+              onPress={() => router.push(`/book/${encodeURIComponent(item.bookUrl)}`)}
+              onLongPress={() => showBookMenu(item)}
+            />
+          )}
+        />
+      )}
+    </View>
+  );
+}
+
+function EmptyShelf({ colors }: { colors: typeof LIGHT }) {
+  return (
+    <View style={styles.empty}>
+      <Text style={[styles.emptyTitle, { color: colors.text }]}>书架是空的</Text>
+      <Text style={[styles.emptyHint, { color: colors.textSecondary }]}>
+        点击右上角 + 导入书源，然后搜索添加书籍
+      </Text>
+    </View>
+  );
+}
+
+function showBookMenu(book: Book) {
+  Alert.alert(book.name, book.author, [
+    { text: '取消', style: 'cancel' },
+    {
+      text: '从书架移除',
+      style: 'destructive',
+      onPress: async () => {
+        await BookDao.delete(book.bookUrl);
+      },
+    },
+  ]);
+}
+
+const LIGHT = {
+  bg: '#F8F5F0',
+  text: '#222',
+  textSecondary: '#888',
+  border: '#EBEBEB',
+  card: '#FFF',
+};
+const DARK = {
+  bg: '#1A1A1A',
+  text: '#EEE',
+  textSecondary: '#777',
+  border: '#2E2E2E',
+  card: '#242424',
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  groupBar: { maxHeight: 44, borderBottomWidth: 0.5 },
+  groupTab: { paddingHorizontal: 16, paddingVertical: 10 },
+  groupTabText: { fontSize: 14, fontWeight: '500' },
+  toolbar: {
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+    paddingHorizontal: 12, paddingVertical: 6, borderBottomWidth: 0.5,
+  },
+  toolbarRight: { flexDirection: 'row', gap: 8 },
+  iconBtn: { padding: 6 },
+  countText: { fontSize: 12 },
+  list: { padding: 8 },
+  empty: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, gap: 8 },
+  emptyTitle: { fontSize: 18, fontWeight: '600' },
+  emptyHint: { fontSize: 14, textAlign: 'center', lineHeight: 22 },
+});

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,0 +1,128 @@
+/**
+ * 设置页面
+ */
+
+import React from 'react';
+import {
+  View, Text, Pressable, StyleSheet, ScrollView, useColorScheme, Alert,
+} from 'react-native';
+import { router } from 'expo-router';
+import { BookOpen, Download, Trash2, Info, ChevronRight, Rss } from 'lucide-react-native';
+
+export default function SettingsScreen() {
+  const isDark = useColorScheme() === 'dark';
+  const colors = isDark ? DARK : LIGHT;
+
+  const sections: Section[] = [
+    {
+      title: '订阅管理',
+      items: [
+        {
+          icon: <Rss size={20} color="#4CAF50" />,
+          label: '订阅源列表',
+          hint: '管理 RSS/番茄等订阅源',
+          onPress: () => router.push('/rsssource'),
+        },
+        {
+          icon: <Download size={20} color="#5B8AF0" />,
+          label: '导入书源/订阅源',
+          hint: '支持 legado Android JSON，自动识别格式',
+          onPress: () => router.push('/booksource/import'),
+        },
+      ],
+    },
+    {
+      title: '书源管理',
+      items: [
+        {
+          icon: <BookOpen size={20} color="#E8735A" />,
+          label: '书源列表',
+          onPress: () => router.push('/booksource'),
+        },
+      ],
+    },
+    {
+      title: '数据',
+      items: [
+        {
+          icon: <Trash2 size={20} color="#E05C5C" />,
+          label: '清除缓存',
+          onPress: () =>
+            Alert.alert('清除缓存', '确定清除所有章节缓存？', [
+              { text: '取消', style: 'cancel' },
+              { text: '清除', style: 'destructive', onPress: () => {} },
+            ]),
+        },
+      ],
+    },
+    {
+      title: '关于',
+      items: [
+        {
+          icon: <Info size={20} color="#888" />,
+          label: '关于 legado iOS',
+          hint: '基于开源阅读 legado 复刻',
+          onPress: () => {},
+        },
+      ],
+    },
+  ];
+
+  return (
+    <ScrollView style={[styles.container, { backgroundColor: colors.bg }]}>
+      {sections.map((section) => (
+        <View key={section.title} style={styles.section}>
+          <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>{section.title}</Text>
+          <View style={[styles.card, { backgroundColor: colors.card, borderColor: colors.border }]}>
+            {section.items.map((item, i) => (
+              <React.Fragment key={item.label}>
+                <Pressable
+                  style={({ pressed }) => [styles.row, pressed && { opacity: 0.6 }]}
+                  onPress={item.onPress}
+                >
+                  <View style={styles.rowLeft}>
+                    {item.icon}
+                    <View style={styles.rowText}>
+                      <Text style={[styles.rowLabel, { color: colors.text }]}>{item.label}</Text>
+                      {item.hint && (
+                        <Text style={[styles.rowHint, { color: colors.textSecondary }]}>{item.hint}</Text>
+                      )}
+                    </View>
+                  </View>
+                  <ChevronRight size={18} color={colors.textSecondary} />
+                </Pressable>
+                {i < section.items.length - 1 && (
+                  <View style={[styles.divider, { backgroundColor: colors.border }]} />
+                )}
+              </React.Fragment>
+            ))}
+          </View>
+        </View>
+      ))}
+    </ScrollView>
+  );
+}
+
+interface SettingItem {
+  icon: React.ReactNode;
+  label: string;
+  hint?: string;
+  onPress: () => void;
+}
+interface Section { title: string; items: SettingItem[] }
+
+const LIGHT = { bg: '#F5F5F5', text: '#222', textSecondary: '#888', card: '#FFF', border: '#EBEBEB' };
+const DARK = { bg: '#111', text: '#EEE', textSecondary: '#666', card: '#1E1E1E', border: '#2E2E2E' };
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  section: { marginTop: 24, paddingHorizontal: 16 },
+  sectionTitle: { fontSize: 12, fontWeight: '600', textTransform: 'uppercase', marginBottom: 8, letterSpacing: 0.5 },
+  card: { borderRadius: 12, overflow: 'hidden', borderWidth: 0.5 },
+  row: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingHorizontal: 16, paddingVertical: 14 },
+  rowLeft: { flexDirection: 'row', alignItems: 'center', gap: 12, flex: 1 },
+  rowText: { flex: 1 },
+  rowLabel: { fontSize: 16 },
+  rowHint: { fontSize: 12, marginTop: 2 },
+  divider: { height: 0.5, marginLeft: 52 },
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,0 +1,25 @@
+import { Stack } from 'expo-router';
+
+export default function RootLayout() {
+  return (
+    <Stack screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="(tabs)" />
+      <Stack.Screen name="booksource/index" options={{ headerShown: false }} />
+      <Stack.Screen name="booksource/import" options={{ headerShown: false }} />
+      <Stack.Screen name="rsssource/index" options={{ headerShown: false }} />
+      <Stack.Screen
+        name="reader/[id]"
+        options={{ headerShown: false, animation: 'slide_from_right' }}
+      />
+      <Stack.Screen
+        name="book/[id]"
+        options={{
+          headerShown: true,
+          headerTitle: '',
+          headerTransparent: true,
+          animation: 'slide_from_right',
+        }}
+      />
+    </Stack>
+  );
+}

--- a/app/book/[id].tsx
+++ b/app/book/[id].tsx
@@ -1,0 +1,211 @@
+/**
+ * 书籍详情页 — T0052
+ * 显示封面、简介、目录，支持加入书架和开始阅读
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+  View, Text, ScrollView, Pressable, StyleSheet,
+  Image, useColorScheme, ActivityIndicator, Alert,
+} from 'react-native';
+import { Stack, router, useLocalSearchParams } from 'expo-router';
+import { BookSourceDao } from '@/data/dao/BookSourceDao';
+import { BookDao } from '@/data/dao/BookDao';
+import { BookChapterDao } from '@/data/dao/BookChapterDao';
+import { Book } from '@/data/models/Book';
+import { BookChapter } from '@/data/models/BookChapter';
+import { getBookInfo, getChapterList } from '@/core/network/WebBook';
+import { BookmarkPlus, BookOpen, List } from 'lucide-react-native';
+
+export default function BookDetailScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const bookUrl = decodeURIComponent(id ?? '');
+  const isDark = useColorScheme() === 'dark';
+  const colors = isDark ? DARK : LIGHT;
+
+  const [book, setBook] = useState<Book | null>(null);
+  const [chapters, setChapters] = useState<BookChapter[]>([]);
+  const [inShelf, setInShelf] = useState(false);
+  const [loadingInfo, setLoadingInfo] = useState(false);
+  const [loadingToc, setLoadingToc] = useState(false);
+
+  useEffect(() => {
+    BookDao.getByUrl(bookUrl).then((b) => {
+      if (b) { setBook(b); setInShelf(true); }
+    });
+  }, [bookUrl]);
+
+  useEffect(() => {
+    if (!book) return;
+    BookChapterDao.getByBook(book.bookUrl).then(setChapters);
+  }, [book]);
+
+  const fetchInfo = async () => {
+    if (!book) return;
+    const source = await BookSourceDao.getByUrl(book.origin);
+    if (!source) return;
+    setLoadingInfo(true);
+    try {
+      const info = await getBookInfo(source, book);
+      const updated = { ...book, ...info };
+      setBook(updated);
+      if (inShelf) await BookDao.upsert(updated);
+    } catch (e) {
+      Alert.alert('获取失败', (e as Error).message);
+    } finally {
+      setLoadingInfo(false);
+    }
+  };
+
+  const fetchToc = async () => {
+    if (!book) return;
+    const source = await BookSourceDao.getByUrl(book.origin);
+    if (!source) return;
+    setLoadingToc(true);
+    try {
+      const chs = await getChapterList(source, book);
+      setChapters(chs);
+      if (inShelf) {
+        await BookChapterDao.deleteByBook(book.bookUrl);
+        await BookChapterDao.upsertMany(chs);
+        const updated = { ...book, totalChapterNum: chs.length, latestChapterTitle: chs[chs.length - 1]?.title };
+        setBook(updated);
+        await BookDao.upsert(updated);
+      }
+    } catch (e) {
+      Alert.alert('获取目录失败', (e as Error).message);
+    } finally {
+      setLoadingToc(false);
+    }
+  };
+
+  const addToShelf = async () => {
+    if (!book) return;
+    await BookDao.upsert(book);
+    if (chapters.length) await BookChapterDao.upsertMany(chapters);
+    setInShelf(true);
+    Alert.alert('已加入书架');
+  };
+
+  const startReading = () => {
+    if (!book) return;
+    router.push(`/reader/${encodeURIComponent(book.bookUrl)}`);
+  };
+
+  if (!book) {
+    return (
+      <View style={[styles.center, { backgroundColor: colors.bg }]}>
+        <ActivityIndicator color="#E8735A" />
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView style={[styles.container, { backgroundColor: colors.bg }]}>
+      <Stack.Screen options={{ headerShown: true, headerTitle: '', headerTransparent: true, headerTintColor: colors.text }} />
+
+      {/* 封面 + 基本信息 */}
+      <View style={[styles.header, { backgroundColor: colors.headerBg }]}>
+        {book.coverUrl ? (
+          <Image source={{ uri: book.coverUrl }} style={styles.cover} />
+        ) : (
+          <View style={[styles.cover, styles.coverPlaceholder]}>
+            <Text style={styles.coverText}>{book.name.slice(0, 4)}</Text>
+          </View>
+        )}
+        <View style={styles.headerMeta}>
+          <Text style={[styles.bookName, { color: colors.text }]}>{book.name}</Text>
+          <Text style={[styles.bookAuthor, { color: colors.textSecondary }]}>{book.author}</Text>
+          <Text style={[styles.bookKind, { color: colors.textSecondary }]}>{book.kind ?? ''}</Text>
+          <Text style={[styles.bookSource, { color: colors.textSecondary }]}>{book.originName}</Text>
+        </View>
+      </View>
+
+      {/* 操作按钮 */}
+      <View style={styles.actions}>
+        {!inShelf ? (
+          <Pressable style={styles.primaryBtn} onPress={addToShelf}>
+            <BookmarkPlus size={18} color="#FFF" />
+            <Text style={styles.primaryBtnText}>加入书架</Text>
+          </Pressable>
+        ) : (
+          <Pressable style={styles.primaryBtn} onPress={startReading}>
+            <BookOpen size={18} color="#FFF" />
+            <Text style={styles.primaryBtnText}>开始阅读</Text>
+          </Pressable>
+        )}
+        <Pressable style={[styles.secondaryBtn, { borderColor: colors.border }]} onPress={fetchToc}>
+          {loadingToc ? <ActivityIndicator size="small" color="#E8735A" /> : <List size={18} color="#E8735A" />}
+          <Text style={[styles.secondaryBtnText, { color: '#E8735A' }]}>获取目录</Text>
+        </Pressable>
+      </View>
+
+      {/* 简介 */}
+      <Pressable style={styles.section} onPress={fetchInfo}>
+        <View style={styles.sectionHeader}>
+          <Text style={[styles.sectionTitle, { color: colors.text }]}>简介</Text>
+          {loadingInfo && <ActivityIndicator size="small" color="#E8735A" />}
+        </View>
+        <Text style={[styles.intro, { color: colors.textSecondary }]} numberOfLines={5}>
+          {book.intro ?? book.customIntro ?? '点击获取简介'}
+        </Text>
+      </Pressable>
+
+      {/* 目录预览 */}
+      <View style={styles.section}>
+        <View style={styles.sectionHeader}>
+          <Text style={[styles.sectionTitle, { color: colors.text }]}>
+            目录 {chapters.length > 0 ? `(${chapters.length})` : ''}
+          </Text>
+        </View>
+        {chapters.slice(0, 10).map((ch) => (
+          <Pressable
+            key={ch.url}
+            style={[styles.chapterRow, { borderBottomColor: colors.border }]}
+            onPress={() => router.push(`/reader/${encodeURIComponent(book.bookUrl)}?chapter=${ch.index}`)}
+          >
+            <Text style={[styles.chapterTitle, { color: colors.text }]} numberOfLines={1}>{ch.title}</Text>
+          </Pressable>
+        ))}
+        {chapters.length > 10 && (
+          <Text style={[styles.moreChapters, { color: colors.textSecondary }]}>
+            还有 {chapters.length - 10} 章…
+          </Text>
+        )}
+        {chapters.length === 0 && (
+          <Text style={[styles.noChapters, { color: colors.textSecondary }]}>点击「获取目录」加载章节</Text>
+        )}
+      </View>
+    </ScrollView>
+  );
+}
+
+const LIGHT = { bg: '#FFF', text: '#222', textSecondary: '#888', border: '#EBEBEB', headerBg: '#F8F5F0' };
+const DARK = { bg: '#1A1A1A', text: '#EEE', textSecondary: '#777', border: '#2E2E2E', headerBg: '#111' };
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  header: { flexDirection: 'row', padding: 16, paddingTop: 80, gap: 16 },
+  cover: { width: 100, height: 133, borderRadius: 6 },
+  coverPlaceholder: { backgroundColor: '#C4B5A0', alignItems: 'center', justifyContent: 'center' },
+  coverText: { color: '#FFF', fontSize: 14, fontWeight: '700', textAlign: 'center', padding: 8 },
+  headerMeta: { flex: 1, gap: 6, justifyContent: 'flex-end' },
+  bookName: { fontSize: 20, fontWeight: '700', lineHeight: 26 },
+  bookAuthor: { fontSize: 14 },
+  bookKind: { fontSize: 12 },
+  bookSource: { fontSize: 12 },
+  actions: { flexDirection: 'row', gap: 12, padding: 16 },
+  primaryBtn: { flex: 1, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', backgroundColor: '#E8735A', borderRadius: 10, paddingVertical: 12, gap: 6 },
+  primaryBtnText: { color: '#FFF', fontSize: 15, fontWeight: '600' },
+  secondaryBtn: { flex: 1, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderRadius: 10, paddingVertical: 12, gap: 6 },
+  secondaryBtnText: { fontSize: 15, fontWeight: '600' },
+  section: { padding: 16, borderTopWidth: 8, borderTopColor: '#F5F5F5' },
+  sectionHeader: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 },
+  sectionTitle: { fontSize: 16, fontWeight: '600' },
+  intro: { fontSize: 14, lineHeight: 22 },
+  chapterRow: { paddingVertical: 12, borderBottomWidth: 0.5 },
+  chapterTitle: { fontSize: 14 },
+  moreChapters: { fontSize: 13, paddingVertical: 8, textAlign: 'center' },
+  noChapters: { fontSize: 13, paddingVertical: 8, textAlign: 'center' },
+});

--- a/app/booksource/import.tsx
+++ b/app/booksource/import.tsx
@@ -1,0 +1,196 @@
+/**
+ * 书源/订阅源导入页面 — 支持 legado Android 书源 JSON 和订阅源 JSON
+ */
+
+import React, { useState } from 'react';
+import {
+  View, Text, Pressable, StyleSheet, TextInput,
+  useColorScheme, Alert, ActivityIndicator, ScrollView,
+} from 'react-native';
+import { Stack, router } from 'expo-router';
+import * as DocumentPicker from 'expo-document-picker';
+import * as FileSystem from 'expo-file-system';
+import { BookSourceImporter, ImportResult } from '@/core/network/BookSourceImporter';
+import { RssSourceImporter, RssImportResult } from '@/core/network/RssSourceImporter';
+import { isRssSource } from '@/core/network/RssSourceImporter';
+
+/** Test subscription source URL */
+const TEST_RSS_URL = 'https://raw.githubusercontent.com/shidahuilang/shuyuan-bak/refs/heads/main/%E5%A4%A7%E7%81%B0%E7%8B%BC%E8%AE%A2%E9%98%85%E6%BA%90.json';
+
+type Tab = 'file' | 'url' | 'paste';
+
+interface AnyResult { total: number; success: number; failed: number; errors: string[] }
+
+export default function BookSourceImportScreen() {
+  const isDark = useColorScheme() === 'dark';
+  const colors = isDark ? DARK : LIGHT;
+
+  const [tab, setTab] = useState<Tab>('url');
+  const [url, setUrl] = useState(TEST_RSS_URL);
+  const [pasteText, setPasteText] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<AnyResult | null>(null);
+
+  const handleImport = async (jsonText: string) => {
+    setLoading(true);
+    setResult(null);
+    try {
+      let res: AnyResult;
+      // Auto-detect: check first item for sourceUrl (RssSource) vs bookSourceUrl (BookSource)
+      let parsed: unknown;
+      try { parsed = JSON.parse(jsonText.trim()); } catch { parsed = null; }
+      const first = Array.isArray(parsed) ? parsed[0] : parsed;
+
+      if (first && isRssSource(first)) {
+        res = await RssSourceImporter.importFromJson(jsonText);
+        if (res.success > 0) {
+          Alert.alert('导入成功', `成功导入 ${res.success} 个订阅源`, [
+            { text: '确定', onPress: () => router.back() },
+          ]);
+        } else {
+          Alert.alert('导入失败', res.errors[0] ?? '无法解析订阅源 JSON');
+        }
+      } else {
+        res = await BookSourceImporter.importFromJson(jsonText);
+        if (res.success > 0) {
+          Alert.alert('导入成功', `成功导入 ${res.success} 个书源`, [
+            { text: '确定', onPress: () => router.back() },
+          ]);
+        } else {
+          Alert.alert('导入失败', res.errors[0] ?? '无法解析书源 JSON');
+        }
+      }
+      setResult(res);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const pickFile = async () => {
+    const res = await DocumentPicker.getDocumentAsync({ type: ['application/json', 'text/plain', '*/*'] });
+    if (res.canceled || !res.assets?.[0]) return;
+    const text = await FileSystem.readAsStringAsync(res.assets[0].uri);
+    await handleImport(text);
+  };
+
+  const importFromUrl = async () => {
+    if (!url.trim()) return;
+    setLoading(true);
+    try {
+      const resp = await fetch(url.trim());
+      const text = await resp.text();
+      await handleImport(text);
+    } catch (e) {
+      Alert.alert('请求失败', (e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <ScrollView style={[styles.container, { backgroundColor: colors.bg }]}>
+      <Stack.Screen options={{ headerShown: true, headerTitle: '导入书源/订阅源', headerStyle: { backgroundColor: colors.bg }, headerTintColor: colors.text }} />
+
+      {/* Tab 切换 */}
+      <View style={[styles.tabs, { borderBottomColor: colors.border }]}>
+        {(['file', 'url', 'paste'] as Tab[]).map((t) => (
+          <Pressable key={t} style={[styles.tab, tab === t && styles.tabActive]} onPress={() => setTab(t)}>
+            <Text style={[styles.tabText, { color: tab === t ? '#E8735A' : colors.textSecondary }]}>
+              {t === 'file' ? '本地文件' : t === 'url' ? '网络地址' : '粘贴文本'}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <View style={styles.content}>
+        {tab === 'file' && (
+          <View style={styles.section}>
+            <Text style={[styles.hint, { color: colors.textSecondary }]}>
+              支持导入 legado Android 导出的书源/订阅源 JSON 文件（自动识别格式）
+            </Text>
+            <Pressable style={styles.primaryBtn} onPress={pickFile} disabled={loading}>
+              {loading ? <ActivityIndicator color="#FFF" /> : <Text style={styles.primaryBtnText}>选择 JSON 文件</Text>}
+            </Pressable>
+          </View>
+        )}
+
+        {tab === 'url' && (
+          <View style={styles.section}>
+            <Text style={[styles.label, { color: colors.text }]}>订阅地址</Text>
+            <TextInput
+              style={[styles.input, { backgroundColor: colors.card, borderColor: colors.border, color: colors.text }]}
+              placeholder="https://..."
+              placeholderTextColor={colors.textSecondary}
+              value={url}
+              onChangeText={setUrl}
+              autoCapitalize="none"
+              keyboardType="url"
+            />
+            <Text style={[styles.testHint, { color: colors.textSecondary }]}>
+              💡 已预填「大灰狼订阅源」测试地址，可直接导入
+            </Text>
+            <Pressable style={styles.primaryBtn} onPress={importFromUrl} disabled={loading || !url.trim()}>
+              {loading ? <ActivityIndicator color="#FFF" /> : <Text style={styles.primaryBtnText}>导入</Text>}
+            </Pressable>
+          </View>
+        )}
+
+        {tab === 'paste' && (
+          <View style={styles.section}>
+            <Text style={[styles.label, { color: colors.text }]}>粘贴书源/订阅源 JSON</Text>
+            <TextInput
+              style={[styles.textarea, { backgroundColor: colors.card, borderColor: colors.border, color: colors.text }]}
+              placeholder='[{"bookSourceName": "...", "bookSourceUrl": "..."}, ...]'
+              placeholderTextColor={colors.textSecondary}
+              value={pasteText}
+              onChangeText={setPasteText}
+              multiline
+              autoCapitalize="none"
+            />
+            <Pressable
+              style={[styles.primaryBtn, !pasteText.trim() && { opacity: 0.4 }]}
+              onPress={() => handleImport(pasteText)}
+              disabled={loading || !pasteText.trim()}
+            >
+              {loading ? <ActivityIndicator color="#FFF" /> : <Text style={styles.primaryBtnText}>导入</Text>}
+            </Pressable>
+          </View>
+        )}
+
+        {result && (
+          <View style={[styles.resultBox, { backgroundColor: colors.card, borderColor: colors.border }]}>
+            <Text style={[styles.resultText, { color: colors.text }]}>
+              总计 {result.total} 个 · 成功 {result.success} 个 · 失败 {result.failed} 个
+            </Text>
+            {result.errors.slice(0, 3).map((e, i) => (
+              <Text key={i} style={[styles.errorText, { color: '#E05C5C' }]}>{e}</Text>
+            ))}
+          </View>
+        )}
+      </View>
+    </ScrollView>
+  );
+}
+
+const LIGHT = { bg: '#F5F5F5', text: '#222', textSecondary: '#888', card: '#FFF', border: '#EBEBEB' };
+const DARK = { bg: '#111', text: '#EEE', textSecondary: '#666', card: '#1E1E1E', border: '#2E2E2E' };
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  tabs: { flexDirection: 'row', borderBottomWidth: 0.5 },
+  tab: { flex: 1, alignItems: 'center', paddingVertical: 12 },
+  tabActive: { borderBottomWidth: 2, borderBottomColor: '#E8735A' },
+  tabText: { fontSize: 14, fontWeight: '500' },
+  content: { padding: 16 },
+  section: { gap: 12 },
+  hint: { fontSize: 13, lineHeight: 20 },
+  label: { fontSize: 15, fontWeight: '500' },
+  input: { borderWidth: 1, borderRadius: 10, padding: 12, fontSize: 14 },
+  textarea: { borderWidth: 1, borderRadius: 10, padding: 12, fontSize: 13, minHeight: 160, textAlignVertical: 'top' },
+  primaryBtn: { backgroundColor: '#E8735A', borderRadius: 10, paddingVertical: 14, alignItems: 'center' },
+  primaryBtnText: { color: '#FFF', fontSize: 16, fontWeight: '600' },
+  testHint: { fontSize: 12, lineHeight: 18, fontStyle: 'italic' },
+  resultBox: { marginTop: 16, padding: 16, borderRadius: 10, borderWidth: 0.5, gap: 6 },
+  resultText: { fontSize: 14, fontWeight: '500' },
+  errorText: { fontSize: 12 },
+});

--- a/app/booksource/index.tsx
+++ b/app/booksource/index.tsx
@@ -1,0 +1,142 @@
+/**
+ * 书源管理页面 — T0080
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  View, Text, FlatList, Pressable, StyleSheet, Switch,
+  useColorScheme, Alert, TextInput,
+} from 'react-native';
+import { Stack, router } from 'expo-router';
+import { BookSource } from '@/data/models/BookSource';
+import { BookSourceDao } from '@/data/dao/BookSourceDao';
+import { Trash2, Plus, Search } from 'lucide-react-native';
+
+export default function BookSourceScreen() {
+  const isDark = useColorScheme() === 'dark';
+  const colors = isDark ? DARK : LIGHT;
+
+  const [sources, setSources] = useState<BookSource[]>([]);
+  const [query, setQuery] = useState('');
+
+  const load = useCallback(async () => {
+    const all = await BookSourceDao.getAll();
+    setSources(all);
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const filtered = query
+    ? sources.filter(
+        (s) =>
+          s.bookSourceName.includes(query) ||
+          s.bookSourceUrl.includes(query) ||
+          (s.bookSourceGroup?.includes(query) ?? false),
+      )
+    : sources;
+
+  const toggleEnabled = async (source: BookSource) => {
+    await BookSourceDao.setEnabled(source.bookSourceUrl, !source.enabled);
+    setSources((prev) =>
+      prev.map((s) => s.bookSourceUrl === source.bookSourceUrl ? { ...s, enabled: !s.enabled } : s),
+    );
+  };
+
+  const deleteSource = (source: BookSource) => {
+    Alert.alert('删除书源', `确定删除「${source.bookSourceName}」？`, [
+      { text: '取消', style: 'cancel' },
+      {
+        text: '删除', style: 'destructive',
+        onPress: async () => {
+          await BookSourceDao.delete(source.bookSourceUrl);
+          setSources((prev) => prev.filter((s) => s.bookSourceUrl !== source.bookSourceUrl));
+        },
+      },
+    ]);
+  };
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.bg }]}>
+      <Stack.Screen
+        options={{
+          headerShown: true,
+          headerTitle: '书源管理',
+          headerStyle: { backgroundColor: colors.bg },
+          headerTintColor: colors.text,
+          headerRight: () => (
+            <Pressable onPress={() => router.push('/booksource/import')} style={{ marginRight: 16 }}>
+              <Plus size={22} color="#E8735A" />
+            </Pressable>
+          ),
+        }}
+      />
+      <View style={[styles.searchBar, { backgroundColor: colors.card, borderColor: colors.border }]}>
+        <Search size={16} color={colors.textSecondary} />
+        <TextInput
+          style={[styles.searchInput, { color: colors.text }]}
+          placeholder="搜索书源名称/URL/分组"
+          placeholderTextColor={colors.textSecondary}
+          value={query}
+          onChangeText={setQuery}
+        />
+      </View>
+      <Text style={[styles.countText, { color: colors.textSecondary }]}>
+        共 {sources.length} 个，启用 {sources.filter((s) => s.enabled).length} 个
+      </Text>
+      <FlatList
+        data={filtered}
+        keyExtractor={(s) => s.bookSourceUrl}
+        renderItem={({ item }) => (
+          <SourceRow source={item} colors={colors}
+            onToggle={() => toggleEnabled(item)} onDelete={() => deleteSource(item)} />
+        )}
+        ListEmptyComponent={
+          <View style={styles.empty}>
+            <Text style={{ color: colors.textSecondary }}>
+              {query ? '无匹配书源' : '暂无书源，点击右上角 + 导入'}
+            </Text>
+          </View>
+        }
+      />
+    </View>
+  );
+}
+
+function SourceRow({ source, colors, onToggle, onDelete }: {
+  source: BookSource; colors: typeof LIGHT; onToggle: () => void; onDelete: () => void;
+}) {
+  return (
+    <View style={[styles.row, { borderBottomColor: colors.border }]}>
+      <View style={styles.rowLeft}>
+        <Text style={[styles.sourceName, { color: colors.text }]} numberOfLines={1}>{source.bookSourceName}</Text>
+        <Text style={[styles.sourceUrl, { color: colors.textSecondary }]} numberOfLines={1}>
+          {source.bookSourceGroup ? `${source.bookSourceGroup} · ` : ''}{source.bookSourceUrl}
+        </Text>
+      </View>
+      <View style={styles.rowRight}>
+        <Switch value={source.enabled} onValueChange={onToggle}
+          trackColor={{ true: '#E8735A' }} thumbColor="#FFF" />
+        <Pressable onPress={onDelete} style={styles.deleteBtn}>
+          <Trash2 size={18} color="#E05C5C" />
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const LIGHT = { bg: '#F5F5F5', text: '#222', textSecondary: '#888', card: '#FFF', border: '#EBEBEB' };
+const DARK = { bg: '#111', text: '#EEE', textSecondary: '#666', card: '#1E1E1E', border: '#2E2E2E' };
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  searchBar: { flexDirection: 'row', alignItems: 'center', margin: 12, padding: 10, borderRadius: 10, borderWidth: 0.5, gap: 8 },
+  searchInput: { flex: 1, fontSize: 14, padding: 0 },
+  countText: { fontSize: 12, paddingHorizontal: 16, marginBottom: 4 },
+  row: { flexDirection: 'row', alignItems: 'center', paddingHorizontal: 16, paddingVertical: 12, borderBottomWidth: 0.5 },
+  rowLeft: { flex: 1 },
+  rowRight: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  sourceName: { fontSize: 15, fontWeight: '500' },
+  sourceUrl: { fontSize: 12, marginTop: 2 },
+  deleteBtn: { padding: 4 },
+  empty: { padding: 32, alignItems: 'center' },
+});

--- a/app/reader/[id].tsx
+++ b/app/reader/[id].tsx
@@ -6,8 +6,8 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   View, Text, ScrollView, Pressable, StyleSheet,
-  useColorScheme, ActivityIndicator, StatusBar, Dimensions, Modal,
-  Slider,
+  useColorScheme, ActivityIndicator, StatusBar, Modal,
+  FlatList, SafeAreaView,
 } from 'react-native';
 import { Stack, router, useLocalSearchParams } from 'expo-router';
 import { BookDao } from '@/data/dao/BookDao';
@@ -17,9 +17,7 @@ import { Book } from '@/data/models/Book';
 import { BookChapter } from '@/data/models/BookChapter';
 import { getContent } from '@/core/network/WebBook';
 import { DEFAULT_READ_CONFIG, ReadConfig } from '@/data/models/ReadConfig';
-import { Settings, ChevronLeft, ChevronRight, List } from 'lucide-react-native';
-
-const { width: SCREEN_W } = Dimensions.get('window');
+import { Settings, ChevronLeft, ChevronRight, List, X } from 'lucide-react-native';
 
 export default function ReaderScreen() {
   const { id, chapter: chapterParam } = useLocalSearchParams<{ id: string; chapter?: string }>();
@@ -33,6 +31,7 @@ export default function ReaderScreen() {
   const [loading, setLoading] = useState(false);
   const [showUI, setShowUI] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
+  const [showToc, setShowToc] = useState(false);
   const [config, setConfig] = useState<ReadConfig>(DEFAULT_READ_CONFIG);
 
   const scrollRef = useRef<ScrollView>(null);
@@ -153,6 +152,9 @@ export default function ReaderScreen() {
           <Text style={[styles.barChapter, { color: textColor }]} numberOfLines={1}>
             {chapter?.title ?? `${currentIndex + 1}/${chapters.length}`}
           </Text>
+          <Pressable onPress={() => { setShowUI(false); setShowToc(true); }} style={styles.barBtn}>
+            <List size={22} color={textColor} />
+          </Pressable>
           <Pressable onPress={() => goChapter(1)} disabled={currentIndex >= chapters.length - 1} style={styles.barBtn}>
             <ChevronRight size={22} color={currentIndex >= chapters.length - 1 ? '#AAA' : textColor} />
           </Pressable>
@@ -165,6 +167,18 @@ export default function ReaderScreen() {
         config={config}
         onChange={setConfig}
         onClose={() => setShowSettings(false)}
+      />
+
+      {/* 目录面板 */}
+      <TocDrawer
+        visible={showToc}
+        chapters={chapters}
+        currentIndex={currentIndex}
+        onSelect={(i) => { setCurrentIndex(i); setShowToc(false); }}
+        onClose={() => setShowToc(false)}
+        isDark={isDark}
+        textColor={textColor}
+        bgColor={bgColor}
       />
     </View>
   );
@@ -231,7 +245,58 @@ function SettingsPanel({ visible, config, onChange, onClose }: {
   );
 }
 
-function formatContent(text: string, indent: number): string {
+function TocDrawer({ visible, chapters, currentIndex, onSelect, onClose, isDark, textColor, bgColor }: {
+  visible: boolean; chapters: BookChapter[]; currentIndex: number;
+  onSelect: (i: number) => void; onClose: () => void;
+  isDark: boolean; textColor: string; bgColor: string;
+}) {
+  const bg = isDark ? '#1A1A1A' : '#FAFAFA';
+  const border = isDark ? '#333' : '#EBEBEB';
+  const tocRef = useRef<FlatList>(null);
+
+  useEffect(() => {
+    if (visible && tocRef.current && chapters.length > 0) {
+      tocRef.current.scrollToIndex({ index: Math.max(0, currentIndex), animated: false });
+    }
+  }, [visible, currentIndex, chapters.length]);
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <View style={styles.tocOverlay}>
+        <Pressable style={{ flex: 1 }} onPress={onClose} />
+        <SafeAreaView style={[styles.tocDrawer, { backgroundColor: bg }]}>
+          <View style={[styles.tocHeader, { borderBottomColor: border }]}>
+            <Text style={[styles.tocTitle, { color: textColor }]}>目录</Text>
+            <Pressable onPress={onClose} style={{ padding: 8 }}>
+              <X size={20} color={textColor} />
+            </Pressable>
+          </View>
+          <FlatList
+            ref={tocRef}
+            data={chapters}
+            keyExtractor={(c) => c.url}
+            getItemLayout={(_, index) => ({ length: 48, offset: 48 * index, index })}
+            renderItem={({ item: c, index }) => (
+              <Pressable
+                style={[styles.tocItem, { borderBottomColor: border },
+                  index === currentIndex && { backgroundColor: isDark ? '#2A2020' : '#FFF0EA' }]}
+                onPress={() => onSelect(index)}
+              >
+                <Text style={[styles.tocItemText,
+                  { color: index === currentIndex ? '#E8735A' : textColor }]}
+                  numberOfLines={1}>
+                  {c.title}
+                </Text>
+              </Pressable>
+            )}
+          />
+        </SafeAreaView>
+      </View>
+    </Modal>
+  );
+}
+
+(text: string, indent: number): string {
   if (!text) return '';
   const pad = '\u3000'.repeat(indent); // 全角空格缩进
   return text
@@ -275,4 +340,10 @@ const styles = StyleSheet.create({
   bgOptions: { flexDirection: 'row', gap: 10 },
   bgOption: { width: 32, height: 32, borderRadius: 16, borderWidth: 1, borderColor: '#DDD' },
   bgOptionActive: { borderWidth: 3, borderColor: '#E8735A' },
+  tocOverlay: { flex: 1, flexDirection: 'row', backgroundColor: 'rgba(0,0,0,0.4)' },
+  tocDrawer: { width: '72%', alignSelf: 'flex-end' },
+  tocHeader: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingHorizontal: 16, paddingVertical: 12, borderBottomWidth: 0.5 },
+  tocTitle: { fontSize: 17, fontWeight: '700' },
+  tocItem: { paddingHorizontal: 16, paddingVertical: 14, borderBottomWidth: 0.5 },
+  tocItemText: { fontSize: 14 },
 });

--- a/app/reader/[id].tsx
+++ b/app/reader/[id].tsx
@@ -1,0 +1,278 @@
+/**
+ * 阅读器页面 — T0060
+ * 基础实现：滚动模式 + 阅读设置面板
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  View, Text, ScrollView, Pressable, StyleSheet,
+  useColorScheme, ActivityIndicator, StatusBar, Dimensions, Modal,
+  Slider,
+} from 'react-native';
+import { Stack, router, useLocalSearchParams } from 'expo-router';
+import { BookDao } from '@/data/dao/BookDao';
+import { BookChapterDao } from '@/data/dao/BookChapterDao';
+import { BookSourceDao } from '@/data/dao/BookSourceDao';
+import { Book } from '@/data/models/Book';
+import { BookChapter } from '@/data/models/BookChapter';
+import { getContent } from '@/core/network/WebBook';
+import { DEFAULT_READ_CONFIG, ReadConfig } from '@/data/models/ReadConfig';
+import { Settings, ChevronLeft, ChevronRight, List } from 'lucide-react-native';
+
+const { width: SCREEN_W } = Dimensions.get('window');
+
+export default function ReaderScreen() {
+  const { id, chapter: chapterParam } = useLocalSearchParams<{ id: string; chapter?: string }>();
+  const bookUrl = decodeURIComponent(id ?? '');
+  const isDark = useColorScheme() === 'dark';
+
+  const [book, setBook] = useState<Book | null>(null);
+  const [chapters, setChapters] = useState<BookChapter[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(Number(chapterParam ?? 0));
+  const [content, setContent] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [showUI, setShowUI] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
+  const [config, setConfig] = useState<ReadConfig>(DEFAULT_READ_CONFIG);
+
+  const scrollRef = useRef<ScrollView>(null);
+
+  // 初始化
+  useEffect(() => {
+    BookDao.getByUrl(bookUrl).then((b) => {
+      if (!b) return;
+      setBook(b);
+      const idx = Number(chapterParam ?? b.durChapterIndex ?? 0);
+      setCurrentIndex(idx);
+    });
+    BookChapterDao.getByBook(bookUrl).then(setChapters);
+  }, [bookUrl, chapterParam]);
+
+  // 加载章节内容
+  const loadContent = useCallback(async (index: number) => {
+    if (!book || chapters.length === 0) return;
+    const chapter = chapters[index];
+    if (!chapter) return;
+
+    setLoading(true);
+    setContent('');
+    scrollRef.current?.scrollTo({ y: 0, animated: false });
+
+    try {
+      const source = await BookSourceDao.getByUrl(book.origin);
+      if (!source) {
+        setContent('无法找到书源，请检查书源是否存在。');
+        return;
+      }
+      const text = await getContent(source, book, chapter);
+      setContent(text || '（本章无内容）');
+      // 更新阅读进度
+      await BookDao.updateProgress(bookUrl, index, 0);
+    } catch (e) {
+      setContent(`加载失败：${(e as Error).message}`);
+    } finally {
+      setLoading(false);
+    }
+  }, [book, chapters, bookUrl]);
+
+  useEffect(() => {
+    if (book && chapters.length > 0) {
+      loadContent(currentIndex);
+    }
+  }, [book, chapters, currentIndex, loadContent]);
+
+  const goChapter = (delta: number) => {
+    const next = currentIndex + delta;
+    if (next < 0 || next >= chapters.length) return;
+    setCurrentIndex(next);
+  };
+
+  const bgColor = isDark ? config.bgStrNight ?? '#1A1A1A' : config.bgStr ?? '#FFF8F0';
+  const textColor = isDark ? config.textColorNight : config.textColor;
+  const chapter = chapters[currentIndex];
+
+  return (
+    <View style={[styles.container, { backgroundColor: bgColor }]}>
+      <Stack.Screen options={{ headerShown: false }} />
+      <StatusBar hidden={!showUI} />
+
+      {/* 可点击遮罩层：点击中间显示/隐藏 UI */}
+      <Pressable style={StyleSheet.absoluteFill} onPress={() => setShowUI((v) => !v)}>
+        {/* 内容 */}
+        <ScrollView ref={scrollRef} style={styles.scroll} scrollEventThrottle={100}>
+          {/* 章节标题 */}
+          <Text style={[styles.chapterTitle, {
+            color: textColor, fontSize: config.titleSize,
+            paddingHorizontal: config.paddingLeft,
+            paddingTop: config.paddingTop + (showUI ? 44 : 0),
+            textAlign: config.titleAlign === 1 ? 'center' : 'left',
+          }]}>
+            {chapter?.title ?? ''}
+          </Text>
+
+          {loading ? (
+            <View style={styles.loadingBox}>
+              <ActivityIndicator color="#E8735A" />
+            </View>
+          ) : (
+            <Text style={[styles.contentText, {
+              color: textColor,
+              fontSize: config.textSize,
+              lineHeight: config.textSize + config.lineSpacingExtra,
+              letterSpacing: config.letterSpacing,
+              paddingHorizontal: config.paddingLeft,
+              paddingBottom: config.paddingBottom,
+            }]}>
+              {formatContent(content, config.indent)}
+            </Text>
+          )}
+        </ScrollView>
+      </Pressable>
+
+      {/* 顶部工具栏 */}
+      {showUI && (
+        <View style={[styles.topBar, { backgroundColor: bgColor + 'EE' }]}>
+          <Pressable onPress={() => router.back()} style={styles.barBtn}>
+            <ChevronLeft size={24} color={textColor} />
+          </Pressable>
+          <Text style={[styles.barTitle, { color: textColor }]} numberOfLines={1}>
+            {book?.name ?? ''}
+          </Text>
+          <Pressable onPress={() => setShowSettings(true)} style={styles.barBtn}>
+            <Settings size={22} color={textColor} />
+          </Pressable>
+        </View>
+      )}
+
+      {/* 底部翻页栏 */}
+      {showUI && (
+        <View style={[styles.bottomBar, { backgroundColor: bgColor + 'EE' }]}>
+          <Pressable onPress={() => goChapter(-1)} disabled={currentIndex <= 0} style={styles.barBtn}>
+            <ChevronLeft size={22} color={currentIndex <= 0 ? '#AAA' : textColor} />
+          </Pressable>
+          <Text style={[styles.barChapter, { color: textColor }]} numberOfLines={1}>
+            {chapter?.title ?? `${currentIndex + 1}/${chapters.length}`}
+          </Text>
+          <Pressable onPress={() => goChapter(1)} disabled={currentIndex >= chapters.length - 1} style={styles.barBtn}>
+            <ChevronRight size={22} color={currentIndex >= chapters.length - 1 ? '#AAA' : textColor} />
+          </Pressable>
+        </View>
+      )}
+
+      {/* 阅读设置面板 */}
+      <SettingsPanel
+        visible={showSettings}
+        config={config}
+        onChange={setConfig}
+        onClose={() => setShowSettings(false)}
+      />
+    </View>
+  );
+}
+
+function SettingsPanel({ visible, config, onChange, onClose }: {
+  visible: boolean; config: ReadConfig;
+  onChange: (c: ReadConfig) => void; onClose: () => void;
+}) {
+  const isDark = useColorScheme() === 'dark';
+  const bg = isDark ? '#222' : '#FFF';
+  const text = isDark ? '#EEE' : '#333';
+
+  const BG_OPTIONS = ['#FFF8F0', '#E8F5E9', '#F0F0F0', '#1A1A2E', '#FFFFFF'];
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <Pressable style={styles.overlay} onPress={onClose} />
+      <View style={[styles.settingsPanel, { backgroundColor: bg }]}>
+        <Text style={[styles.settingsTitle, { color: text }]}>阅读设置</Text>
+
+        {/* 字号 */}
+        <View style={styles.settingRow}>
+          <Text style={[styles.settingLabel, { color: text }]}>字号 {config.textSize}</Text>
+          <View style={styles.stepper}>
+            <Pressable style={styles.stepBtn} onPress={() => onChange({ ...config, textSize: Math.max(12, config.textSize - 1) })}>
+              <Text style={styles.stepBtnText}>A-</Text>
+            </Pressable>
+            <Pressable style={styles.stepBtn} onPress={() => onChange({ ...config, textSize: Math.min(32, config.textSize + 1) })}>
+              <Text style={styles.stepBtnText}>A+</Text>
+            </Pressable>
+          </View>
+        </View>
+
+        {/* 行距 */}
+        <View style={styles.settingRow}>
+          <Text style={[styles.settingLabel, { color: text }]}>行距 {config.lineSpacingExtra}</Text>
+          <View style={styles.stepper}>
+            <Pressable style={styles.stepBtn} onPress={() => onChange({ ...config, lineSpacingExtra: Math.max(4, config.lineSpacingExtra - 2) })}>
+              <Text style={styles.stepBtnText}>−</Text>
+            </Pressable>
+            <Pressable style={styles.stepBtn} onPress={() => onChange({ ...config, lineSpacingExtra: Math.min(30, config.lineSpacingExtra + 2) })}>
+              <Text style={styles.stepBtnText}>+</Text>
+            </Pressable>
+          </View>
+        </View>
+
+        {/* 背景色 */}
+        <View style={styles.settingRow}>
+          <Text style={[styles.settingLabel, { color: text }]}>背景</Text>
+          <View style={styles.bgOptions}>
+            {BG_OPTIONS.map((c) => (
+              <Pressable
+                key={c}
+                style={[styles.bgOption, { backgroundColor: c },
+                  config.bgStr === c && styles.bgOptionActive]}
+                onPress={() => onChange({ ...config, bgStr: c })}
+              />
+            ))}
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+function formatContent(text: string, indent: number): string {
+  if (!text) return '';
+  const pad = '\u3000'.repeat(indent); // 全角空格缩进
+  return text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => pad + line)
+    .join('\n\n');
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  scroll: { flex: 1 },
+  chapterTitle: { fontWeight: '700', marginBottom: 24, lineHeight: 36 },
+  contentText: { textAlign: 'justify' },
+  loadingBox: { flex: 1, alignItems: 'center', justifyContent: 'center', paddingVertical: 60 },
+  topBar: {
+    position: 'absolute', top: 0, left: 0, right: 0,
+    flexDirection: 'row', alignItems: 'center',
+    paddingTop: 44, paddingBottom: 8, paddingHorizontal: 4,
+  },
+  bottomBar: {
+    position: 'absolute', bottom: 0, left: 0, right: 0,
+    flexDirection: 'row', alignItems: 'center',
+    paddingBottom: 28, paddingTop: 8, paddingHorizontal: 4,
+  },
+  barBtn: { padding: 10 },
+  barTitle: { flex: 1, fontSize: 16, fontWeight: '500', textAlign: 'center' },
+  barChapter: { flex: 1, fontSize: 13, textAlign: 'center' },
+  overlay: { flex: 1 },
+  settingsPanel: {
+    borderTopLeftRadius: 20, borderTopRightRadius: 20,
+    padding: 24, gap: 20, paddingBottom: 40,
+  },
+  settingsTitle: { fontSize: 17, fontWeight: '700', textAlign: 'center' },
+  settingRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  settingLabel: { fontSize: 15 },
+  stepper: { flexDirection: 'row', gap: 8 },
+  stepBtn: { backgroundColor: '#E8735A', borderRadius: 8, paddingHorizontal: 16, paddingVertical: 8 },
+  stepBtnText: { color: '#FFF', fontWeight: '700', fontSize: 14 },
+  bgOptions: { flexDirection: 'row', gap: 10 },
+  bgOption: { width: 32, height: 32, borderRadius: 16, borderWidth: 1, borderColor: '#DDD' },
+  bgOptionActive: { borderWidth: 3, borderColor: '#E8735A' },
+});

--- a/app/rsssource/index.tsx
+++ b/app/rsssource/index.tsx
@@ -1,0 +1,133 @@
+/**
+ * 订阅源管理 — list, enable/disable, delete RssSources
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  View, Text, FlatList, Pressable, StyleSheet,
+  useColorScheme, Switch, Alert, TextInput,
+} from 'react-native';
+import { Stack, router } from 'expo-router';
+import { Trash2, Plus } from 'lucide-react-native';
+import { RssSourceDao } from '@/data/dao/RssSourceDao';
+import { RssSource } from '@/data/models/RssSource';
+
+export default function RssSourceManagerScreen() {
+  const isDark = useColorScheme() === 'dark';
+  const colors = isDark ? DARK : LIGHT;
+
+  const [sources, setSources] = useState<RssSource[]>([]);
+  const [query, setQuery] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const all = await RssSourceDao.getAll();
+      setSources(all);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const filtered = query
+    ? sources.filter((s) => s.sourceName.includes(query) || (s.sourceGroup ?? '').includes(query))
+    : sources;
+
+  const toggleEnabled = async (s: RssSource) => {
+    await RssSourceDao.setEnabled(s.sourceUrl, !s.enabled);
+    setSources((prev) => prev.map((x) => x.sourceUrl === s.sourceUrl ? { ...x, enabled: !x.enabled } : x));
+  };
+
+  const deleteSource = (s: RssSource) => {
+    Alert.alert('删除订阅源', `确定删除「${s.sourceName}」？`, [
+      { text: '取消', style: 'cancel' },
+      {
+        text: '删除', style: 'destructive', onPress: async () => {
+          await RssSourceDao.delete(s.sourceUrl);
+          setSources((prev) => prev.filter((x) => x.sourceUrl !== s.sourceUrl));
+        },
+      },
+    ]);
+  };
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.bg }]}>
+      <Stack.Screen
+        options={{
+          headerShown: true,
+          headerTitle: '订阅源管理',
+          headerStyle: { backgroundColor: colors.bg },
+          headerTintColor: colors.text,
+          headerRight: () => (
+            <Pressable onPress={() => router.push('/booksource/import')} style={{ marginRight: 16 }}>
+              <Plus size={22} color={colors.text} />
+            </Pressable>
+          ),
+        }}
+      />
+
+      {/* Search */}
+      <View style={[styles.searchBar, { backgroundColor: colors.card, borderColor: colors.border }]}>
+        <TextInput
+          style={[styles.searchInput, { color: colors.text }]}
+          placeholder="搜索订阅源名称或分组"
+          placeholderTextColor={colors.textSecondary}
+          value={query}
+          onChangeText={setQuery}
+        />
+      </View>
+
+      <Text style={[styles.countText, { color: colors.textSecondary }]}>
+        共 {sources.length} 个订阅源
+      </Text>
+
+      <FlatList
+        data={filtered}
+        keyExtractor={(s) => s.sourceUrl}
+        renderItem={({ item: s }) => (
+          <View style={[styles.row, { backgroundColor: colors.card, borderColor: colors.border }]}>
+            <View style={styles.rowInfo}>
+              <Text style={[styles.name, { color: colors.text }]} numberOfLines={1}>{s.sourceName}</Text>
+              {s.sourceGroup && (
+                <Text style={[styles.group, { color: colors.textSecondary }]}>{s.sourceGroup}</Text>
+              )}
+              <Text style={[styles.url, { color: colors.textSecondary }]} numberOfLines={1}>{s.sourceUrl}</Text>
+            </View>
+            <Switch
+              value={s.enabled}
+              onValueChange={() => toggleEnabled(s)}
+              thumbColor="#FFF"
+              trackColor={{ true: '#E8735A', false: '#CCC' }}
+            />
+            <Pressable onPress={() => deleteSource(s)} style={{ marginLeft: 12 }}>
+              <Trash2 size={18} color="#E05C5C" />
+            </Pressable>
+          </View>
+        )}
+        ItemSeparatorComponent={() => <View style={{ height: 1, backgroundColor: colors.border }} />}
+        contentContainerStyle={styles.list}
+        refreshing={loading}
+        onRefresh={load}
+      />
+    </View>
+  );
+}
+
+const LIGHT = { bg: '#F5F5F5', text: '#222', textSecondary: '#888', card: '#FFF', border: '#EBEBEB' };
+const DARK = { bg: '#111', text: '#EEE', textSecondary: '#666', card: '#1E1E1E', border: '#2E2E2E' };
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  searchBar: { margin: 12, borderRadius: 10, borderWidth: 0.5, paddingHorizontal: 12 },
+  searchInput: { fontSize: 14, paddingVertical: 10 },
+  countText: { fontSize: 12, marginLeft: 16, marginBottom: 4 },
+  list: { paddingBottom: 40 },
+  row: { flexDirection: 'row', alignItems: 'center', padding: 14, borderBottomWidth: 0.5 },
+  rowInfo: { flex: 1, gap: 2 },
+  name: { fontSize: 15, fontWeight: '500' },
+  group: { fontSize: 12 },
+  url: { fontSize: 11 },
+});

--- a/app/search/index.tsx
+++ b/app/search/index.tsx
@@ -1,0 +1,239 @@
+/**
+ * 搜索页面 — T0031
+ * 跨书源并行搜索，结果按书名/作者去重合并
+ */
+
+import React, { useCallback, useRef, useState } from 'react';
+import {
+  View, Text, TextInput, FlatList, Pressable, StyleSheet,
+  useColorScheme, ActivityIndicator, Image, StatusBar,
+  KeyboardAvoidingView, Platform,
+} from 'react-native';
+import { Stack, router } from 'expo-router';
+import { Search, X, BookOpen } from 'lucide-react-native';
+import { BookSourceDao } from '@/data/dao/BookSourceDao';
+import { BookDao } from '@/data/dao/BookDao';
+import { searchBooks, SearchBook } from '@/core/network/WebBook';
+
+interface SearchResult extends SearchBook {
+  sourceUrl: string;
+  sourceName: string;
+}
+
+/** Group results by bookKey = `${name}::${author}` */
+function dedup(results: SearchResult[]): SearchResult[] {
+  const seen = new Map<string, SearchResult>();
+  for (const r of results) {
+    const key = `${r.name}::${r.author ?? ''}`;
+    if (!seen.has(key)) seen.set(key, r);
+  }
+  return Array.from(seen.values());
+}
+
+export default function SearchScreen() {
+  const isDark = useColorScheme() === 'dark';
+  const colors = isDark ? DARK : LIGHT;
+
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [sourceCount, setSourceCount] = useState(0);
+  const [searchedCount, setSearchedCount] = useState(0);
+  const inputRef = useRef<TextInput>(null);
+  const abortRef = useRef(false);
+
+  const doSearch = useCallback(async (keyword: string) => {
+    if (!keyword.trim()) return;
+    abortRef.current = false;
+    setLoading(true);
+    setResults([]);
+    setSearchedCount(0);
+
+    const sources = await BookSourceDao.getEnabled();
+    setSourceCount(sources.length);
+
+    // Search all sources in parallel batches of 5
+    const BATCH = 5;
+    for (let i = 0; i < sources.length; i += BATCH) {
+      if (abortRef.current) break;
+      const batch = sources.slice(i, i + BATCH);
+      await Promise.all(
+        batch.map(async (source) => {
+          if (abortRef.current) return;
+          try {
+            const books = await searchBooks(source, keyword, 1);
+            if (abortRef.current) return;
+            const tagged: SearchResult[] = books.map((b) => ({
+              ...b,
+              sourceUrl: source.bookSourceUrl,
+              sourceName: source.bookSourceName,
+            }));
+            setResults((prev) => dedup([...prev, ...tagged]));
+          } catch {
+            // ignore per-source errors
+          } finally {
+            setSearchedCount((c) => c + 1);
+          }
+        })
+      );
+    }
+    setLoading(false);
+  }, []);
+
+  const cancelSearch = () => {
+    abortRef.current = true;
+    setLoading(false);
+  };
+
+  const addToShelf = async (item: SearchResult) => {
+    const existing = await BookDao.getByUrl(item.bookUrl ?? item.name);
+    if (existing) {
+      router.push(`/book/${encodeURIComponent(existing.bookUrl)}`);
+      return;
+    }
+    router.push({
+      pathname: '/book/[id]',
+      params: { id: encodeURIComponent(item.bookUrl ?? item.name), fromSearch: '1' },
+    });
+  };
+
+  const clearSearch = () => {
+    setQuery('');
+    setResults([]);
+    setLoading(false);
+    abortRef.current = true;
+    inputRef.current?.focus();
+  };
+
+  return (
+    <KeyboardAvoidingView
+      style={[styles.container, { backgroundColor: colors.bg }]}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      <Stack.Screen options={{ headerShown: false }} />
+      <StatusBar barStyle={isDark ? 'light-content' : 'dark-content'} />
+
+      {/* 顶部搜索栏 */}
+      <View style={[styles.header, { backgroundColor: colors.bg, borderBottomColor: colors.border }]}>
+        <Pressable onPress={() => router.back()} style={styles.backBtn}>
+          <X size={22} color={colors.text} />
+        </Pressable>
+        <View style={[styles.inputWrap, { backgroundColor: colors.card, borderColor: colors.border }]}>
+          <Search size={16} color={colors.textSecondary} style={{ marginLeft: 10 }} />
+          <TextInput
+            ref={inputRef}
+            style={[styles.input, { color: colors.text }]}
+            placeholder="搜书名、作者..."
+            placeholderTextColor={colors.textSecondary}
+            value={query}
+            onChangeText={setQuery}
+            returnKeyType="search"
+            autoFocus
+            onSubmitEditing={() => doSearch(query)}
+          />
+          {query.length > 0 && (
+            <Pressable onPress={clearSearch} style={{ paddingHorizontal: 10 }}>
+              <X size={16} color={colors.textSecondary} />
+            </Pressable>
+          )}
+        </View>
+        <Pressable
+          style={[styles.searchBtn, (!query.trim() || loading) && { opacity: 0.5 }]}
+          onPress={loading ? cancelSearch : () => doSearch(query)}
+          disabled={!query.trim() && !loading}
+        >
+          <Text style={styles.searchBtnText}>{loading ? '停止' : '搜索'}</Text>
+        </Pressable>
+      </View>
+
+      {/* 搜索进度 */}
+      {(loading || searchedCount > 0) && (
+        <View style={[styles.progressBar, { backgroundColor: colors.card, borderBottomColor: colors.border }]}>
+          <ActivityIndicator size="small" color="#E8735A" animating={loading} />
+          <Text style={[styles.progressText, { color: colors.textSecondary }]}>
+            {loading
+              ? `搜索中 ${searchedCount}/${sourceCount} 个书源，找到 ${results.length} 本`
+              : `共搜索 ${searchedCount} 个书源，找到 ${results.length} 本`}
+          </Text>
+        </View>
+      )}
+
+      {/* 结果列表 */}
+      <FlatList
+        data={results}
+        keyExtractor={(item, i) => `${item.bookUrl ?? item.name}-${i}`}
+        renderItem={({ item }) => (
+          <Pressable
+            style={[styles.resultRow, { backgroundColor: colors.card, borderBottomColor: colors.border }]}
+            onPress={() => addToShelf(item)}
+          >
+            {item.coverUrl ? (
+              <Image source={{ uri: item.coverUrl }} style={styles.cover} resizeMode="cover" />
+            ) : (
+              <View style={[styles.cover, styles.coverPlaceholder]}>
+                <BookOpen size={22} color="#CCC" />
+              </View>
+            )}
+            <View style={styles.meta}>
+              <Text style={[styles.bookName, { color: colors.text }]} numberOfLines={1}>{item.name}</Text>
+              <Text style={[styles.bookAuthor, { color: colors.textSecondary }]} numberOfLines={1}>
+                {item.author ?? '未知作者'}
+              </Text>
+              {item.intro && (
+                <Text style={[styles.bookIntro, { color: colors.textSecondary }]} numberOfLines={2}>{item.intro}</Text>
+              )}
+              <Text style={[styles.sourceTag, { color: '#E8735A' }]} numberOfLines={1}>{item.sourceName}</Text>
+            </View>
+          </Pressable>
+        )}
+        contentContainerStyle={{ paddingBottom: 40 }}
+        ListEmptyComponent={
+          !loading && query ? (
+            <View style={styles.emptyBox}>
+              <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+                {searchedCount > 0 ? '未找到相关书籍' : '输入书名或作者开始搜索'}
+              </Text>
+            </View>
+          ) : null
+        }
+      />
+    </KeyboardAvoidingView>
+  );
+}
+
+const LIGHT = { bg: '#F5F5F5', text: '#222', textSecondary: '#888', card: '#FFF', border: '#EBEBEB' };
+const DARK  = { bg: '#111',    text: '#EEE', textSecondary: '#666', card: '#1E1E1E', border: '#2E2E2E' };
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row', alignItems: 'center', gap: 8,
+    paddingTop: 52, paddingBottom: 10, paddingHorizontal: 12,
+    borderBottomWidth: 0.5,
+  },
+  backBtn: { padding: 6 },
+  inputWrap: {
+    flex: 1, flexDirection: 'row', alignItems: 'center',
+    borderRadius: 10, borderWidth: 0.5, height: 40,
+  },
+  input: { flex: 1, fontSize: 15, paddingHorizontal: 8 },
+  searchBtn: { backgroundColor: '#E8735A', borderRadius: 8, paddingHorizontal: 14, paddingVertical: 8 },
+  searchBtnText: { color: '#FFF', fontWeight: '600', fontSize: 14 },
+  progressBar: {
+    flexDirection: 'row', alignItems: 'center', gap: 8,
+    paddingHorizontal: 16, paddingVertical: 8, borderBottomWidth: 0.5,
+  },
+  progressText: { fontSize: 12 },
+  resultRow: {
+    flexDirection: 'row', padding: 14, borderBottomWidth: 0.5, gap: 12,
+  },
+  cover: { width: 60, height: 80, borderRadius: 6 },
+  coverPlaceholder: { backgroundColor: '#EEE', alignItems: 'center', justifyContent: 'center' },
+  meta: { flex: 1, gap: 4 },
+  bookName: { fontSize: 16, fontWeight: '600' },
+  bookAuthor: { fontSize: 13 },
+  bookIntro: { fontSize: 12, lineHeight: 17 },
+  sourceTag: { fontSize: 11, fontWeight: '500' },
+  emptyBox: { alignItems: 'center', paddingTop: 80 },
+  emptyText: { fontSize: 15 },
+});

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,9 +19,9 @@
 | ID | 任务 | 前置 | Spec | 状态 |
 |----|------|------|------|------|
 | T0001 | Expo 项目初始化（package.json / app.json / tsconfig） | — | — | ✅ |
-| T0002 | 数据模型（BookSource / Book / BookChapter / RssSource / ReplaceRule） | T0001 | [spec](specs/T0002-data-models.md) | 📐 |
-| T0003 | SQLite 数据库层（DAO + migration） | T0002 | — | ⬜ |
-| T0004 | expo-router 导航结构（Tab + Stack） | T0001 | — | ⬜ |
+| [T0002](https://github.com/szylover/legado-ios/issues/1) | 数据模型（BookSource / Book / BookChapter / RssSource / ReplaceRule） | T0001 | [spec](specs/T0002-data-models.md) | ✅ |
+| [T0003](https://github.com/szylover/legado-ios/issues/2) | SQLite 数据库层（DAO + migration） | T0002 | — | ⬜ |
+| [T0004](https://github.com/szylover/legado-ios/issues/3) | expo-router 导航结构（Tab + Stack） | T0001 | — | ⬜ |
 
 ---
 
@@ -29,13 +29,13 @@
 
 | ID | 任务 | 前置 | Spec | 状态 |
 |----|------|------|------|------|
-| T0010 | RuleAnalyzer（规则字符串分段器） | T0002 | [spec](specs/T0010-rule-analyzer.md) | 📐 |
-| T0011 | AnalyzeByCSS（cheerio CSS 选择器） | T0010 | — | ⬜ |
-| T0012 | AnalyzeByXPath（xpath + xmldom） | T0010 | — | ⬜ |
-| T0013 | AnalyzeByJSONPath（jsonpath-plus） | T0010 | — | ⬜ |
-| T0014 | AnalyzeByRegex（正则规则） | T0010 | — | ⬜ |
-| T0015 | JSEngine（JS eval 规则，书源内嵌 JS） | T0010 | — | ⬜ |
-| T0016 | AnalyzeRule（主规则入口，组合以上所有） | T0011, T0012, T0013, T0014, T0015 | — | ⬜ |
+| [T0010](https://github.com/szylover/legado-ios/issues/4) | RuleAnalyzer（规则字符串分段器） | T0002 | [spec](specs/T0010-rule-analyzer.md) | 🔨 |
+| [T0011](https://github.com/szylover/legado-ios/issues/5) | AnalyzeByCSS（cheerio CSS 选择器） | T0010 | — | ⬜ |
+| [T0012](https://github.com/szylover/legado-ios/issues/6) | AnalyzeByXPath（xpath + xmldom） | T0010 | — | ⬜ |
+| [T0013](https://github.com/szylover/legado-ios/issues/7) | AnalyzeByJSONPath（jsonpath-plus） | T0010 | — | ⬜ |
+| [T0014](https://github.com/szylover/legado-ios/issues/8) | AnalyzeByRegex（正则规则） | T0010 | — | ⬜ |
+| [T0015](https://github.com/szylover/legado-ios/issues/9) | JSEngine（JS eval 规则，书源内嵌 JS） | T0010 | — | ⬜ |
+| [T0016](https://github.com/szylover/legado-ios/issues/10) | AnalyzeRule（主规则入口，组合以上所有） | T0011, T0012, T0013, T0014, T0015 | — | ⬜ |
 
 ---
 
@@ -43,8 +43,8 @@
 
 | ID | 任务 | 前置 | Spec | 状态 |
 |----|------|------|------|------|
-| T0020 | AnalyzeUrl（URL 模板解析器，支持 POST/Header/变量替换） | T0002 | [spec](specs/T0020-analyze-url.md) | 📐 |
-| T0021 | HttpClient（fetch 封装，User-Agent、Cookie、重定向） | T0020 | — | ⬜ |
+| [T0020](https://github.com/szylover/legado-ios/issues/11) | AnalyzeUrl（URL 模板解析器，支持 POST/Header/变量替换） | T0002 | [spec](specs/T0020-analyze-url.md) | 📐 |
+| [T0021](https://github.com/szylover/legado-ios/issues/12) | HttpClient（fetch 封装，User-Agent、Cookie、重定向） | T0020 | — | ⬜ |
 | T0022 | CookieStore（按域名持久化 Cookie） | T0021 | — | ⬜ |
 
 ---
@@ -53,8 +53,8 @@
 
 | ID | 任务 | 前置 | Spec | 状态 |
 |----|------|------|------|------|
-| T0030 | 书源导入/导出（JSON 解析，兼容 legado Android 格式） | T0003, T0016 | — | ⬜ |
-| T0031 | WebBook.search（通过书源搜索书籍） | T0016, T0022 | — | ⬜ |
+| [T0030](https://github.com/szylover/legado-ios/issues/13) | 书源导入/导出（JSON 解析，兼容 legado Android 格式） | T0003, T0016 | — | ⬜ |
+| [T0031](https://github.com/szylover/legado-ios/issues/14) | WebBook.search（通过书源搜索书籍） | T0016, T0022 | — | ⬜ |
 | T0032 | WebBook.getBookInfo（获取书籍详情页） | T0031 | — | ⬜ |
 | T0033 | WebBook.getChapterList（获取目录） | T0032 | — | ⬜ |
 | T0034 | WebBook.getContent（获取正文） | T0033 | — | ⬜ |
@@ -74,7 +74,7 @@
 
 | ID | 任务 | 前置 | Spec | 状态 |
 |----|------|------|------|------|
-| T0050 | 书架页面（列表/网格切换，分组） | T0003, T0004 | — | ⬜ |
+| [T0050](https://github.com/szylover/legado-ios/issues/15) | 书架页面（列表/网格切换，分组） | T0003, T0004 | — | ⬜ |
 | T0051 | 书籍卡片组件（封面、进度、更新状态） | T0050 | — | ⬜ |
 | T0052 | 书籍详情页 | T0032, T0050 | — | ⬜ |
 
@@ -84,7 +84,7 @@
 
 | ID | 任务 | 前置 | Spec | 状态 |
 |----|------|------|------|------|
-| T0060 | 阅读器基础（文字渲染、滚动翻页） | T0034, T0004 | — | ⬜ |
+| [T0060](https://github.com/szylover/legado-ios/issues/16) | 阅读器基础（文字渲染、滚动翻页） | T0034, T0004 | — | ⬜ |
 | T0061 | 阅读设置面板（字体/字号/行距/背景/亮度） | T0060 | — | ⬜ |
 | T0062 | 翻页动画（仿真翻页） | T0060 | — | ⬜ |
 | T0063 | 目录侧边栏 | T0060 | — | ⬜ |
@@ -126,6 +126,6 @@
 
 | ID | 任务 | 前置 | Spec | 状态 |
 |----|------|------|------|------|
-| T0100 | EAS 构建配置（eas.json） | T0001 | — | ⬜ |
+| [T0100](https://github.com/szylover/legado-ios/issues/17) | EAS 构建配置（eas.json） | T0001 | — | ⬜ |
 | T0101 | OTA 更新配置（expo-updates） | T0100 | — | ⬜ |
 | T0102 | App Store 首次发布 | T0060, T0100 | — | ⬜ |

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,36 @@
+{
+  "cli": {
+    "version": ">= 10.0.0"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "ios": {
+        "simulator": true
+      }
+    },
+    "preview": {
+      "distribution": "internal",
+      "ios": {
+        "simulator": false
+      }
+    },
+    "production": {
+      "ios": {
+        "buildConfiguration": "Release"
+      },
+      "android": {
+        "buildType": "apk"
+      }
+    }
+  },
+  "submit": {
+    "production": {
+      "ios": {
+        "appleId": "",
+        "ascAppId": ""
+      }
+    }
+  }
+}

--- a/src/components/bookshelf/BookCard.tsx
+++ b/src/components/bookshelf/BookCard.tsx
@@ -1,0 +1,119 @@
+/**
+ * BookCard — 书籍卡片组件（网格/列表模式）
+ */
+
+import React from 'react';
+import {
+  View, Text, Pressable, StyleSheet, Image, useColorScheme, Dimensions,
+} from 'react-native';
+import { Book } from '@/data/models/Book';
+
+interface Props {
+  book: Book;
+  mode: 'grid' | 'list';
+  onPress: () => void;
+  onLongPress: () => void;
+}
+
+const SCREEN_W = Dimensions.get('window').width;
+const GRID_ITEM_W = (SCREEN_W - 8 * 2 - 8 * 2) / 3; // 3 columns, 8px padding
+const COVER_RATIO = 4 / 3;
+
+export function BookCard({ book, mode, onPress, onLongPress }: Props) {
+  const isDark = useColorScheme() === 'dark';
+  const colors = isDark ? DARK : LIGHT;
+
+  if (mode === 'list') {
+    return (
+      <Pressable
+        style={[styles.listItem, { backgroundColor: colors.card, borderBottomColor: colors.border }]}
+        onPress={onPress}
+        onLongPress={onLongPress}
+      >
+        <CoverImage uri={book.customCoverUrl ?? book.coverUrl} width={52} />
+        <View style={styles.listMeta}>
+          <Text style={[styles.listTitle, { color: colors.text }]} numberOfLines={1}>{book.name}</Text>
+          <Text style={[styles.listAuthor, { color: colors.textSecondary }]} numberOfLines={1}>
+            {book.author}
+          </Text>
+          <Text style={[styles.listChapter, { color: colors.textSecondary }]} numberOfLines={1}>
+            {book.latestChapterTitle ?? ''}
+          </Text>
+        </View>
+        {book.lastCheckCount > 0 && (
+          <View style={styles.badge}>
+            <Text style={styles.badgeText}>{book.lastCheckCount > 99 ? '99+' : book.lastCheckCount}</Text>
+          </View>
+        )}
+      </Pressable>
+    );
+  }
+
+  // Grid mode
+  return (
+    <Pressable
+      style={[styles.gridItem, { width: GRID_ITEM_W }]}
+      onPress={onPress}
+      onLongPress={onLongPress}
+    >
+      <CoverImage uri={book.customCoverUrl ?? book.coverUrl} width={GRID_ITEM_W} />
+      {book.lastCheckCount > 0 && (
+        <View style={styles.gridBadge}>
+          <Text style={styles.badgeText}>{book.lastCheckCount > 99 ? '99+' : book.lastCheckCount}</Text>
+        </View>
+      )}
+      <Text style={[styles.gridTitle, { color: colors.text }]} numberOfLines={2}>
+        {book.name}
+      </Text>
+    </Pressable>
+  );
+}
+
+function CoverImage({ uri, width }: { uri?: string; width: number }) {
+  const isDark = useColorScheme() === 'dark';
+  const height = width * COVER_RATIO;
+  const placeholder = isDark ? '#2E2E2E' : '#E8E0D8';
+
+  if (!uri) {
+    return <View style={[styles.cover, { width, height, backgroundColor: placeholder }]} />;
+  }
+
+  return (
+    <Image
+      source={{ uri }}
+      style={[styles.cover, { width, height }]}
+      defaultSource={require('@/assets/images/cover-placeholder.png')}
+    />
+  );
+}
+
+const LIGHT = { card: '#FFF', text: '#222', textSecondary: '#888', border: '#EBEBEB' };
+const DARK = { card: '#242424', text: '#EEE', textSecondary: '#777', border: '#2E2E2E' };
+
+const styles = StyleSheet.create({
+  // Grid
+  gridItem: { margin: 4, marginBottom: 12 },
+  gridTitle: { fontSize: 13, marginTop: 6, lineHeight: 18 },
+  gridBadge: {
+    position: 'absolute', top: 4, right: 4,
+    backgroundColor: '#E8735A', borderRadius: 8,
+    paddingHorizontal: 5, paddingVertical: 2,
+  },
+  // List
+  listItem: {
+    flexDirection: 'row', alignItems: 'center',
+    paddingHorizontal: 12, paddingVertical: 10,
+    borderBottomWidth: 0.5, gap: 12,
+  },
+  listMeta: { flex: 1, gap: 3 },
+  listTitle: { fontSize: 16, fontWeight: '500' },
+  listAuthor: { fontSize: 13 },
+  listChapter: { fontSize: 12 },
+  // Shared
+  cover: { borderRadius: 4, backgroundColor: '#DDD' },
+  badge: {
+    backgroundColor: '#E8735A', borderRadius: 8,
+    paddingHorizontal: 6, paddingVertical: 2, alignSelf: 'center',
+  },
+  badgeText: { color: '#FFF', fontSize: 10, fontWeight: '700' },
+});

--- a/src/core/network/AnalyzeUrl.ts
+++ b/src/core/network/AnalyzeUrl.ts
@@ -1,0 +1,162 @@
+/**
+ * AnalyzeUrl — URL 模板解析器
+ * 对应 legado Android: AnalyzeUrl.kt
+ *
+ * 支持：
+ *  - {{js}} 内嵌 JS 表达式
+ *  - <pg> 翻页占位符
+ *  - searchKey / searchPage 变量替换
+ *  - URL 尾部 ,{...} JSON 参数（method/header/body/charset）
+ */
+
+import { JSEngine } from '../ruleEngine/JSEngine';
+
+export type HttpMethod = 'GET' | 'POST';
+
+export interface ParsedUrl {
+  url: string;
+  method: HttpMethod;
+  headers: Record<string, string>;
+  body?: string;
+  charset?: string;
+  retry: number;
+  useWebView: boolean;
+  webJs?: string;
+}
+
+export interface UrlContext {
+  key?: string;        // 搜索关键字
+  page?: number;       // 页码（1-based）
+  baseUrl?: string;
+  [key: string]: unknown;
+}
+
+/** URL 尾部参数 JSON 格式 */
+interface UrlOption {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+  charset?: string;
+  retry?: number;
+  webView?: string | boolean;
+  webJs?: string;
+  js?: string;
+}
+
+const DEFAULT_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) ' +
+  'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
+
+export class AnalyzeUrl {
+  private rawUrl: string;
+  private ctx: UrlContext;
+
+  constructor(rawUrl: string, ctx: UrlContext = {}) {
+    this.rawUrl = rawUrl;
+    this.ctx = ctx;
+  }
+
+  parse(): ParsedUrl {
+    let ruleUrl = this.rawUrl;
+
+    // Step 1: 执行 <js>...</js> 和 @js: 前缀
+    ruleUrl = this.evalJsTags(ruleUrl);
+
+    // Step 2: 替换 {{js 表达式}}
+    ruleUrl = this.evalInlineJs(ruleUrl);
+
+    // Step 3: 替换翻页占位符 <pg,1,2,3> 或 <pg>
+    ruleUrl = this.replacePage(ruleUrl);
+
+    // Step 4: 替换 searchKey / searchPage / key
+    ruleUrl = this.replaceVariables(ruleUrl);
+
+    // Step 5: 拆分 URL 主体 和 尾部 ,{...} JSON 参数
+    return this.splitUrlAndOptions(ruleUrl);
+  }
+
+  private evalJsTags(url: string): string {
+    // 匹配 @js:xxx 到行尾 或 <js>...</js>
+    const jsTagRe = /<js>([\s\S]*?)<\/js>|@js:([\s\S]+)$/gi;
+    return url.replace(jsTagRe, (_, block, inline) => {
+      const code = block ?? inline;
+      return JSEngine.evalString(code.trim(), { ...this.ctx, result: url });
+    });
+  }
+
+  private evalInlineJs(url: string): string {
+    if (!url.includes('{{')) return url;
+    return url.replace(/\{\{([\s\S]*?)\}\}/g, (_, code) => {
+      const result = JSEngine.evalString(code.trim(), { ...this.ctx, result: '' });
+      return result;
+    });
+  }
+
+  private replacePage(url: string): string {
+    const page = this.ctx.page ?? 1;
+    // <pg,p1,p2,...> → 按页码索引取值
+    url = url.replace(/<pg,([^>]+)>/gi, (_, options) => {
+      const parts = options.split(',').map((s: string) => s.trim());
+      return parts[page - 1] ?? parts[parts.length - 1] ?? String(page);
+    });
+    // 简单 <pg> → 直接替换页码
+    url = url.replace(/<pg>/gi, String(page));
+    return url;
+  }
+
+  private replaceVariables(url: string): string {
+    const key = this.ctx.key ?? '';
+    const page = this.ctx.page ?? 1;
+    return url
+      .replace(/searchKey/g, encodeURIComponent(key))
+      .replace(/searchPage/g, String(page))
+      .replace(/\bkey\b/g, encodeURIComponent(key))
+      .replace(/\bpage\b/g, String(page));
+  }
+
+  private splitUrlAndOptions(ruleUrl: string): ParsedUrl {
+    // 末尾 ,{...} 参数（取最后一个 ,{ 位置）
+    const optionStart = findOptionsStart(ruleUrl);
+    const urlPart = optionStart !== -1 ? ruleUrl.slice(0, optionStart).trim() : ruleUrl.trim();
+    const optionStr = optionStart !== -1 ? ruleUrl.slice(optionStart + 1).trim() : null;
+
+    const result: ParsedUrl = {
+      url: urlPart,
+      method: 'GET',
+      headers: { 'User-Agent': DEFAULT_UA },
+      retry: 0,
+      useWebView: false,
+    };
+
+    if (optionStr) {
+      try {
+        const opt: UrlOption = JSON.parse(optionStr);
+        if (opt.method?.toUpperCase() === 'POST') result.method = 'POST';
+        if (opt.headers) Object.assign(result.headers, opt.headers);
+        if (opt.body) result.body = opt.body;
+        if (opt.charset) result.charset = opt.charset;
+        if (opt.retry) result.retry = opt.retry;
+        if (opt.webView) result.useWebView = true;
+        if (opt.webJs) result.webJs = opt.webJs;
+        if (opt.js) {
+          result.url = JSEngine.evalString(opt.js, { ...this.ctx, result: result.url });
+        }
+      } catch {
+        // 非法 JSON，忽略
+      }
+    }
+
+    return result;
+  }
+}
+
+/** 找到最后一个 ,{ 的位置（URL 末尾参数的起始） */
+function findOptionsStart(url: string): number {
+  // 从末尾向前找 ,{
+  for (let i = url.length - 1; i >= 0; i--) {
+    if (url[i] === '{') {
+      if (i > 0 && url[i - 1] === ',') return i - 1;
+    }
+  }
+  return -1;
+}

--- a/src/core/network/BookSourceImporter.ts
+++ b/src/core/network/BookSourceImporter.ts
@@ -1,0 +1,114 @@
+/**
+ * BookSourceImporter — 书源导入/导出
+ * 支持从 legado Android 导出的 JSON 文件直接导入
+ */
+
+import { BookSource } from '../data/models/BookSource';
+import { BookSourceDao } from '../data/dao/BookSourceDao';
+
+/** 验证一个对象是否是合法的书源 */
+function isValidBookSource(obj: unknown): obj is BookSource {
+  if (!obj || typeof obj !== 'object') return false;
+  const src = obj as Record<string, unknown>;
+  return typeof src.bookSourceUrl === 'string' && src.bookSourceUrl.length > 0
+    && typeof src.bookSourceName === 'string';
+}
+
+/** 规范化书源（补全默认值） */
+function normalizeSource(raw: Record<string, unknown>): BookSource {
+  return {
+    bookSourceUrl: String(raw.bookSourceUrl ?? ''),
+    bookSourceName: String(raw.bookSourceName ?? ''),
+    bookSourceGroup: raw.bookSourceGroup ? String(raw.bookSourceGroup) : undefined,
+    bookSourceType: Number(raw.bookSourceType ?? 0),
+    bookUrlPattern: raw.bookUrlPattern ? String(raw.bookUrlPattern) : undefined,
+    customOrder: Number(raw.customOrder ?? 0),
+    enabled: raw.enabled !== false,
+    enabledExplore: raw.enabledExplore !== false,
+    enabledCookieJar: raw.enabledCookieJar != null ? Boolean(raw.enabledCookieJar) : undefined,
+    concurrentRate: raw.concurrentRate ? String(raw.concurrentRate) : undefined,
+    header: raw.header ? String(raw.header) : undefined,
+    loginUrl: raw.loginUrl ? String(raw.loginUrl) : undefined,
+    loginUi: raw.loginUi ? String(raw.loginUi) : undefined,
+    loginCheckJs: raw.loginCheckJs ? String(raw.loginCheckJs) : undefined,
+    coverDecodeJs: raw.coverDecodeJs ? String(raw.coverDecodeJs) : undefined,
+    jsLib: raw.jsLib ? String(raw.jsLib) : undefined,
+    bookSourceComment: raw.bookSourceComment ? String(raw.bookSourceComment) : undefined,
+    lastUpdateTime: Number(raw.lastUpdateTime ?? Date.now()),
+    respondTime: Number(raw.respondTime ?? 180000),
+    weight: Number(raw.weight ?? 0),
+    exploreUrl: raw.exploreUrl ? String(raw.exploreUrl) : undefined,
+    searchUrl: raw.searchUrl ? String(raw.searchUrl) : undefined,
+    ruleExplore: parseSubRule(raw.ruleExplore),
+    ruleSearch: parseSubRule(raw.ruleSearch),
+    ruleBookInfo: parseSubRule(raw.ruleBookInfo),
+    ruleToc: parseSubRule(raw.ruleToc),
+    ruleContent: parseSubRule(raw.ruleContent),
+  };
+}
+
+function parseSubRule<T>(val: unknown): T | undefined {
+  if (!val) return undefined;
+  if (typeof val === 'object') return val as T;
+  if (typeof val === 'string') {
+    try { return JSON.parse(val) as T; } catch { return undefined; }
+  }
+  return undefined;
+}
+
+export interface ImportResult {
+  total: number;
+  success: number;
+  failed: number;
+  errors: string[];
+}
+
+export const BookSourceImporter = {
+  /**
+   * 从 JSON 字符串导入书源
+   * 支持单个对象或数组
+   */
+  async importFromJson(jsonText: string): Promise<ImportResult> {
+    const result: ImportResult = { total: 0, success: 0, failed: 0, errors: [] };
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(jsonText);
+    } catch (e) {
+      result.errors.push(`JSON 解析失败: ${(e as Error).message}`);
+      return result;
+    }
+
+    const items = Array.isArray(parsed) ? parsed : [parsed];
+    result.total = items.length;
+
+    const valid: BookSource[] = [];
+    for (const item of items) {
+      if (isValidBookSource(item)) {
+        valid.push(normalizeSource(item as Record<string, unknown>));
+      } else {
+        result.failed++;
+        result.errors.push(`无效书源: ${JSON.stringify(item).slice(0, 60)}`);
+      }
+    }
+
+    const dbResult = await BookSourceDao.importMany(valid);
+    result.success = dbResult.success;
+    result.failed += dbResult.failed;
+
+    return result;
+  },
+
+  /** 导出所有书源为 JSON 字符串 */
+  async exportAll(): Promise<string> {
+    const sources = await BookSourceDao.getAll();
+    return JSON.stringify(sources, null, 2);
+  },
+
+  /** 导出指定 URL 的书源 */
+  async exportSelected(urls: string[]): Promise<string> {
+    const all = await BookSourceDao.getAll();
+    const selected = all.filter((s) => urls.includes(s.bookSourceUrl));
+    return JSON.stringify(selected, null, 2);
+  },
+};

--- a/src/core/network/CookieStore.ts
+++ b/src/core/network/CookieStore.ts
@@ -1,0 +1,77 @@
+/**
+ * CookieStore — 按域名持久化 Cookie
+ * 对应 legado Android: CookieStore.kt
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const COOKIE_PREFIX = '@legado_cookies_';
+
+function getDomain(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
+function parseCookieHeader(header: string): Record<string, string> {
+  const cookies: Record<string, string> = {};
+  header.split(';').forEach((part) => {
+    const [k, ...vs] = part.trim().split('=');
+    const key = k?.trim();
+    if (key && key.toLowerCase() !== 'path' && key.toLowerCase() !== 'expires' &&
+        key.toLowerCase() !== 'domain' && key.toLowerCase() !== 'secure' &&
+        key.toLowerCase() !== 'httponly' && key.toLowerCase() !== 'samesite' &&
+        key.toLowerCase() !== 'max-age') {
+      cookies[key] = vs.join('=').trim();
+    }
+  });
+  return cookies;
+}
+
+export const CookieStore = {
+  async get(url: string): Promise<string> {
+    const domain = getDomain(url);
+    try {
+      const stored = await AsyncStorage.getItem(COOKIE_PREFIX + domain);
+      if (!stored) return '';
+      const obj: Record<string, string> = JSON.parse(stored);
+      return Object.entries(obj).map(([k, v]) => `${k}=${v}`).join('; ');
+    } catch {
+      return '';
+    }
+  },
+
+  async save(url: string, setCookieHeaders: string[]): Promise<void> {
+    const domain = getDomain(url);
+    try {
+      const stored = await AsyncStorage.getItem(COOKIE_PREFIX + domain);
+      const existing: Record<string, string> = stored ? JSON.parse(stored) : {};
+      for (const header of setCookieHeaders) {
+        Object.assign(existing, parseCookieHeader(header));
+      }
+      await AsyncStorage.setItem(COOKIE_PREFIX + domain, JSON.stringify(existing));
+    } catch {
+      // ignore
+    }
+  },
+
+  async set(url: string, cookies: string): Promise<void> {
+    const domain = getDomain(url);
+    const parsed = parseCookieHeader(cookies);
+    try {
+      const stored = await AsyncStorage.getItem(COOKIE_PREFIX + domain);
+      const existing: Record<string, string> = stored ? JSON.parse(stored) : {};
+      Object.assign(existing, parsed);
+      await AsyncStorage.setItem(COOKIE_PREFIX + domain, JSON.stringify(existing));
+    } catch {
+      // ignore
+    }
+  },
+
+  async clear(url: string): Promise<void> {
+    const domain = getDomain(url);
+    await AsyncStorage.removeItem(COOKIE_PREFIX + domain);
+  },
+};

--- a/src/core/network/HttpClient.ts
+++ b/src/core/network/HttpClient.ts
@@ -1,0 +1,114 @@
+/**
+ * HttpClient — fetch 封装
+ * 对应 legado Android: OkHttp 封装
+ *
+ * 功能：
+ *  - 自动携带/保存 Cookie（CookieStore）
+ *  - 自定义 Headers（书源 header 字段）
+ *  - 重试
+ *  - 响应 charset 自动检测
+ *  - GET / POST（form / json）
+ */
+
+import { ParsedUrl } from './AnalyzeUrl';
+import { CookieStore } from './CookieStore';
+
+export interface HttpResponse {
+  text: string;
+  url: string;
+  statusCode: number;
+  headers: Record<string, string>;
+}
+
+export interface HttpOptions extends ParsedUrl {
+  /** 额外 Headers（书源 header 字段，JSON 字符串或对象） */
+  sourceHeader?: string | Record<string, string>;
+  /** 是否启用 CookieJar */
+  enableCookieJar?: boolean;
+  /** 超时毫秒 */
+  timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+export async function httpFetch(options: HttpOptions): Promise<HttpResponse> {
+  const {
+    url,
+    method,
+    headers: parsedHeaders,
+    body,
+    sourceHeader,
+    enableCookieJar = false,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    retry = 0,
+  } = options;
+
+  const headers: Record<string, string> = { ...parsedHeaders };
+
+  // 合并书源 header
+  if (sourceHeader) {
+    const srcHeaders =
+      typeof sourceHeader === 'string' ? safeParseJson<Record<string, string>>(sourceHeader) : sourceHeader;
+    if (srcHeaders) Object.assign(headers, srcHeaders);
+  }
+
+  // 携带 Cookie
+  if (enableCookieJar) {
+    const cookie = await CookieStore.get(url);
+    if (cookie) headers['Cookie'] = cookie;
+  }
+
+  // POST body content-type
+  if (method === 'POST' && body && !headers['Content-Type']) {
+    headers['Content-Type'] = body.trimStart().startsWith('{')
+      ? 'application/json'
+      : 'application/x-www-form-urlencoded';
+  }
+
+  let lastError: Error | null = null;
+  for (let attempt = 0; attempt <= retry; attempt++) {
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+      const resp = await fetch(url, {
+        method,
+        headers,
+        body: method === 'POST' ? body : undefined,
+        signal: controller.signal,
+      });
+
+      clearTimeout(timer);
+
+      // 保存 Cookie
+      if (enableCookieJar) {
+        const setCookies = resp.headers.getAll?.('set-cookie') ?? [];
+        if (setCookies.length) await CookieStore.save(url, setCookies);
+      }
+
+      const text = await resp.text();
+      const respHeaders: Record<string, string> = {};
+      resp.headers.forEach((v, k) => { respHeaders[k] = v; });
+
+      return {
+        text,
+        url: resp.url || url,
+        statusCode: resp.status,
+        headers: respHeaders,
+      };
+    } catch (e) {
+      lastError = e as Error;
+      if (attempt < retry) await sleep(500 * (attempt + 1));
+    }
+  }
+
+  throw lastError ?? new Error(`Request failed: ${url}`);
+}
+
+function safeParseJson<T>(s: string): T | null {
+  try { return JSON.parse(s) as T; } catch { return null; }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/src/core/network/RssSourceImporter.ts
+++ b/src/core/network/RssSourceImporter.ts
@@ -1,0 +1,105 @@
+/**
+ * RssSourceImporter — import/export RssSource JSON (legado Android format)
+ */
+
+import { RssSource } from '../models/RssSource';
+import { RssSourceDao } from '../dao/RssSourceDao';
+
+export interface RssImportResult {
+  total: number;
+  success: number;
+  failed: number;
+  errors: string[];
+}
+
+/** Check if a parsed object looks like an RssSource (has sourceUrl + sourceName) */
+export function isRssSource(obj: unknown): obj is Record<string, unknown> {
+  if (!obj || typeof obj !== 'object') return false;
+  const o = obj as Record<string, unknown>;
+  return typeof o.sourceUrl === 'string' && typeof o.sourceName === 'string';
+}
+
+function normalize(raw: Record<string, unknown>): RssSource {
+  return {
+    sourceUrl: String(raw.sourceUrl),
+    sourceName: String(raw.sourceName),
+    sourceGroup: raw.sourceGroup != null ? String(raw.sourceGroup) : undefined,
+    sourceIcon: raw.sourceIcon != null ? String(raw.sourceIcon) : undefined,
+    sourceComment: raw.sourceComment != null ? String(raw.sourceComment) : undefined,
+    enabled: raw.enabled !== false,
+    enabledCookieJar: raw.enabledCookieJar != null ? Boolean(raw.enabledCookieJar) : undefined,
+    enableJs: raw.enableJs != null ? Boolean(raw.enableJs) : undefined,
+    loadWithBaseUrl: raw.loadWithBaseUrl != null ? Boolean(raw.loadWithBaseUrl) : undefined,
+    articleStyle: typeof raw.articleStyle === 'number' ? raw.articleStyle : 0,
+    concurrentRate: raw.concurrentRate != null ? String(raw.concurrentRate) : undefined,
+    header: raw.header != null ? String(raw.header) : undefined,
+    loginUrl: raw.loginUrl != null ? String(raw.loginUrl) : undefined,
+    loginUi: raw.loginUi != null ? String(raw.loginUi) : undefined,
+    loginCheckJs: raw.loginCheckJs != null ? String(raw.loginCheckJs) : undefined,
+    jsLib: raw.jsLib != null ? String(raw.jsLib) : undefined,
+    injectJs: raw.injectJs != null ? String(raw.injectJs) : undefined,
+    shouldOverrideUrlLoading: raw.shouldOverrideUrlLoading != null ? String(raw.shouldOverrideUrlLoading) : undefined,
+    sortUrl: raw.sortUrl != null ? String(raw.sortUrl) : undefined,
+    singleUrl: Boolean(raw.singleUrl),
+    customOrder: typeof raw.customOrder === 'number' ? raw.customOrder : 0,
+    ruleArticles: raw.ruleArticles != null ? String(raw.ruleArticles) : undefined,
+    ruleNextPage: raw.ruleNextPage != null ? String(raw.ruleNextPage) : undefined,
+    ruleTitle: raw.ruleTitle != null ? String(raw.ruleTitle) : undefined,
+    rulePubDate: raw.rulePubDate != null ? String(raw.rulePubDate) : undefined,
+    ruleImage: raw.ruleImage != null ? String(raw.ruleImage) : undefined,
+    ruleLink: raw.ruleLink != null ? String(raw.ruleLink) : undefined,
+    ruleContent: raw.ruleContent != null ? String(raw.ruleContent) : undefined,
+    style: raw.style != null ? String(raw.style) : undefined,
+    webCss: raw.webCss != null ? String(raw.webCss) : undefined,
+    lastUpdateTime: typeof raw.lastUpdateTime === 'number' ? raw.lastUpdateTime : Date.now(),
+  };
+}
+
+export class RssSourceImporter {
+  /** Parse JSON string and batch-import into DB */
+  static async importFromJson(jsonText: string): Promise<RssImportResult> {
+    const result: RssImportResult = { total: 0, success: 0, failed: 0, errors: [] };
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(jsonText.trim());
+    } catch {
+      result.errors.push('JSON 解析失败，请检查格式');
+      return result;
+    }
+
+    const items: unknown[] = Array.isArray(parsed) ? parsed : [parsed];
+    result.total = items.length;
+
+    const valid: RssSource[] = [];
+    for (const item of items) {
+      if (!isRssSource(item)) {
+        result.failed++;
+        result.errors.push(`无效订阅源: ${JSON.stringify(item).slice(0, 60)}`);
+        continue;
+      }
+      try {
+        valid.push(normalize(item as Record<string, unknown>));
+      } catch (e) {
+        result.failed++;
+        result.errors.push(`解析失败: ${(e as Error).message}`);
+      }
+    }
+
+    try {
+      await RssSourceDao.importMany(valid);
+      result.success = valid.length;
+    } catch (e) {
+      result.failed += valid.length;
+      result.errors.push(`数据库写入失败: ${(e as Error).message}`);
+    }
+
+    return result;
+  }
+
+  /** Export all sources as JSON string */
+  static async exportAll(): Promise<string> {
+    const sources = await RssSourceDao.getAll();
+    return JSON.stringify(sources, null, 2);
+  }
+}

--- a/src/core/network/WebBook.ts
+++ b/src/core/network/WebBook.ts
@@ -1,0 +1,227 @@
+/**
+ * WebBook — 通过书源获取书籍信息、目录、正文
+ * 对应 legado Android: webBook/ 下各 worker
+ */
+
+import { BookSource, SearchRule, BookInfoRule, TocRule, ContentRule } from '../data/models/BookSource';
+import { Book } from '../data/models/Book';
+import { BookChapter } from '../data/models/BookChapter';
+import { AnalyzeUrl, UrlContext } from './AnalyzeUrl';
+import { httpFetch } from './HttpClient';
+import { AnalyzeRule } from '../ruleEngine/AnalyzeRule';
+
+function makeJsCtx(source: BookSource, extra?: Record<string, unknown>): UrlContext {
+  return {
+    baseUrl: source.bookSourceUrl,
+    source: { bookSourceUrl: source.bookSourceUrl, bookSourceName: source.bookSourceName },
+    ...extra,
+  };
+}
+
+// ─── 搜索 ────────────────────────────────────────────────────────────────────
+
+export interface SearchResult {
+  name: string;
+  author: string;
+  bookUrl: string;
+  coverUrl?: string;
+  intro?: string;
+  kind?: string;
+  lastChapter?: string;
+  wordCount?: string;
+}
+
+export async function searchBooks(
+  source: BookSource,
+  keyword: string,
+  page = 1,
+): Promise<SearchResult[]> {
+  if (!source.searchUrl || !source.ruleSearch) return [];
+
+  const ctx = makeJsCtx(source, { key: keyword, page });
+  const parsed = new AnalyzeUrl(source.searchUrl, ctx).parse();
+  const resp = await httpFetch({
+    ...parsed,
+    sourceHeader: source.header,
+    enableCookieJar: source.enabledCookieJar,
+  });
+
+  return parseSearchResults(resp.text, resp.url, source.ruleSearch);
+}
+
+function parseSearchResults(
+  html: string,
+  baseUrl: string,
+  rule: SearchRule,
+): SearchResult[] {
+  if (!rule.bookList) return [];
+
+  const analyzer = new AnalyzeRule(html, baseUrl);
+  const bookListHtmls = analyzer.getStringList(rule.bookList);
+  if (!bookListHtmls.length) return [];
+
+  return bookListHtmls.map((itemHtml) => {
+    const itemAnalyzer = new AnalyzeRule(itemHtml, baseUrl);
+    return {
+      name: rule.name ? itemAnalyzer.getString(rule.name) : '',
+      author: rule.author ? itemAnalyzer.getString(rule.author) : '',
+      bookUrl: rule.bookUrl ? resolveUrl(itemAnalyzer.getString(rule.bookUrl), baseUrl) : '',
+      coverUrl: rule.coverUrl ? itemAnalyzer.getString(rule.coverUrl) : undefined,
+      intro: rule.intro ? itemAnalyzer.getString(rule.intro) : undefined,
+      kind: rule.kind ? itemAnalyzer.getString(rule.kind) : undefined,
+      lastChapter: rule.lastChapter ? itemAnalyzer.getString(rule.lastChapter) : undefined,
+      wordCount: rule.wordCount ? itemAnalyzer.getString(rule.wordCount) : undefined,
+    };
+  }).filter((r) => r.name && r.bookUrl);
+}
+
+// ─── 书籍详情 ─────────────────────────────────────────────────────────────────
+
+export async function getBookInfo(source: BookSource, book: Book): Promise<Partial<Book>> {
+  const rule = source.ruleBookInfo;
+  if (!rule) return {};
+
+  const ctx = makeJsCtx(source, { baseUrl: book.bookUrl });
+
+  // init 规则可以改变请求 URL
+  const infoUrl = rule.init
+    ? new AnalyzeUrl(rule.init, { ...ctx, result: book.bookUrl }).parse().url
+    : book.bookUrl;
+
+  const parsed = new AnalyzeUrl(infoUrl, ctx).parse();
+  const resp = await httpFetch({
+    ...parsed,
+    sourceHeader: source.header,
+    enableCookieJar: source.enabledCookieJar,
+  });
+
+  const analyzer = new AnalyzeRule(resp.text, resp.url);
+  return {
+    name: rule.name ? analyzer.getString(rule.name) || book.name : book.name,
+    author: rule.author ? analyzer.getString(rule.author) || book.author : book.author,
+    intro: rule.intro ? analyzer.getString(rule.intro) : book.intro,
+    coverUrl: rule.coverUrl ? analyzer.getString(rule.coverUrl) : book.coverUrl,
+    kind: rule.kind ? analyzer.getString(rule.kind) : book.kind,
+    lastChapter: rule.lastChapter ? analyzer.getString(rule.lastChapter) : undefined,
+    wordCount: rule.wordCount ? analyzer.getString(rule.wordCount) : book.wordCount,
+    tocUrl: rule.tocUrl ? resolveUrl(analyzer.getString(rule.tocUrl), resp.url) : book.tocUrl,
+  };
+}
+
+// ─── 目录 ─────────────────────────────────────────────────────────────────────
+
+export async function getChapterList(
+  source: BookSource,
+  book: Book,
+): Promise<BookChapter[]> {
+  const rule = source.ruleToc;
+  if (!rule) return [];
+
+  const ctx = makeJsCtx(source, { baseUrl: book.tocUrl || book.bookUrl });
+  const chapters: BookChapter[] = [];
+  let tocUrl = book.tocUrl || book.bookUrl;
+  let pageIndex = 0;
+
+  // 支持多页目录
+  while (tocUrl) {
+    const parsed = new AnalyzeUrl(tocUrl, ctx).parse();
+    const resp = await httpFetch({
+      ...parsed,
+      sourceHeader: source.header,
+      enableCookieJar: source.enabledCookieJar,
+    });
+
+    const newChapters = parseToc(resp.text, resp.url, rule, book.bookUrl, pageIndex);
+    chapters.push(...newChapters);
+    pageIndex += newChapters.length;
+
+    // 下一页目录 URL
+    const nextTocUrl = rule.nextTocUrl
+      ? new AnalyzeRule(resp.text, resp.url).getString(rule.nextTocUrl)
+      : '';
+    tocUrl = nextTocUrl && nextTocUrl !== tocUrl ? resolveUrl(nextTocUrl, resp.url) : '';
+  }
+
+  return chapters;
+}
+
+function parseToc(
+  html: string,
+  baseUrl: string,
+  rule: TocRule,
+  bookUrl: string,
+  startIndex: number,
+): BookChapter[] {
+  if (!rule.chapterList) return [];
+  const analyzer = new AnalyzeRule(html, baseUrl);
+  const items = analyzer.getStringList(rule.chapterList);
+
+  return items.map((itemHtml, i) => {
+    const a = new AnalyzeRule(itemHtml, baseUrl);
+    return {
+      bookUrl,
+      index: startIndex + i,
+      title: rule.chapterName ? a.getString(rule.chapterName) : `第${startIndex + i + 1}章`,
+      url: rule.chapterUrl ? resolveUrl(a.getString(rule.chapterUrl), baseUrl) : '',
+      isVolume: rule.isVolume ? a.getString(rule.isVolume) === 'true' : false,
+      isVip: rule.isVip ? a.getString(rule.isVip) === 'true' : false,
+      isPay: rule.isPay ? a.getString(rule.isPay) === 'true' : false,
+      updateTime: rule.updateTime ? a.getString(rule.updateTime) : undefined,
+    } satisfies BookChapter;
+  }).filter((c) => c.title && c.url);
+}
+
+// ─── 正文 ─────────────────────────────────────────────────────────────────────
+
+export async function getContent(
+  source: BookSource,
+  book: Book,
+  chapter: BookChapter,
+): Promise<string> {
+  const rule = source.ruleContent;
+  if (!rule) return '';
+
+  const ctx = makeJsCtx(source, { baseUrl: chapter.url });
+  const parsed = new AnalyzeUrl(chapter.url, ctx).parse();
+  const resp = await httpFetch({
+    ...parsed,
+    sourceHeader: source.header,
+    enableCookieJar: source.enabledCookieJar,
+  });
+
+  return parseContent(resp.text, resp.url, rule, book, chapter);
+}
+
+function parseContent(
+  html: string,
+  baseUrl: string,
+  rule: ContentRule,
+  _book: Book,
+  _chapter: BookChapter,
+): string {
+  const analyzer = new AnalyzeRule(html, baseUrl);
+  let content = rule.content ? analyzer.getString(rule.content) : '';
+
+  // 替换净化
+  if (rule.replaceRegex && content) {
+    const parts = rule.replaceRegex.split('##');
+    if (parts.length >= 2) {
+      const pattern = parts[0];
+      const replacement = parts[1] ?? '';
+      content = content.replace(new RegExp(pattern, 'g'), replacement);
+    }
+  }
+
+  return content.trim();
+}
+
+// ─── 工具 ─────────────────────────────────────────────────────────────────────
+
+function resolveUrl(url: string, base: string): string {
+  if (!url) return '';
+  try {
+    return new URL(url, base).href;
+  } catch {
+    return url;
+  }
+}

--- a/src/core/network/index.ts
+++ b/src/core/network/index.ts
@@ -1,0 +1,5 @@
+export { AnalyzeUrl } from './AnalyzeUrl';
+export type { ParsedUrl, UrlContext } from './AnalyzeUrl';
+export { CookieStore } from './CookieStore';
+export { httpFetch } from './HttpClient';
+export type { HttpResponse, HttpOptions } from './HttpClient';

--- a/src/core/ruleEngine/AnalyzeByCSS.ts
+++ b/src/core/ruleEngine/AnalyzeByCSS.ts
@@ -1,0 +1,85 @@
+/**
+ * AnalyzeByCSS — CSS 选择器解析器
+ * 对应 legado Android: AnalyzeByJSoup.kt
+ * 使用 cheerio 实现
+ */
+
+import * as cheerio from 'cheerio';
+
+export class AnalyzeByCSS {
+  private $: cheerio.CheerioAPI;
+  private root: cheerio.Cheerio<cheerio.AnyNode>;
+
+  constructor(html: string) {
+    this.$ = cheerio.load(html, { decodeEntities: false });
+    this.root = this.$.root();
+  }
+
+  /** 获取元素列表（对应 getElements） */
+  getElements(rule: string): cheerio.Cheerio<cheerio.Element>[] {
+    try {
+      const elements = this.root.find(rule);
+      const result: cheerio.Cheerio<cheerio.Element>[] = [];
+      elements.each((_, el) => {
+        result.push(this.$(el));
+      });
+      return result;
+    } catch {
+      return [];
+    }
+  }
+
+  /** 从 elements 中按规则获取文本列表 */
+  getStringList(rule: string, elements?: cheerio.Cheerio<cheerio.Element>[]): string[] {
+    const src = elements ?? this.getElements(rule);
+    if (!elements) {
+      // rule 本身就是选择器，取文本
+      return this.getElements(rule).map((el) => this.getTextFromElement(el, rule));
+    }
+    return src.map((el) => this.getTextFromElement(el, rule));
+  }
+
+  /** 按选择器获取单个字符串 */
+  getString(rule: string): string {
+    return this.getStringList(rule)[0] ?? '';
+  }
+
+  /**
+   * 从单个元素按 rule 取值
+   * rule 可包含属性后缀：
+   *   "a@href"    → 取 href 属性
+   *   "img@src"   → 取 src 属性
+   *   "div"       → 取 text()
+   *   "div@html"  → 取 innerHTML
+   *   "div@text"  → 取 text()
+   */
+  getStringFromElement(el: cheerio.Cheerio<cheerio.Element>, rule: string): string {
+    // 拆出属性后缀 @attr
+    const atMatch = rule.match(/@([a-zA-Z_:][a-zA-Z0-9_:\-.]*)$/);
+    if (atMatch) {
+      const attr = atMatch[1].toLowerCase();
+      if (attr === 'html' || attr === 'innerhtml') return el.html() ?? '';
+      if (attr === 'text') return el.text().trim();
+      if (attr === 'outerhtml') return cheerio.load(el.toString()).html() ?? '';
+      return el.attr(atMatch[1]) ?? '';
+    }
+    // 没有属性后缀，先找子元素，找不到就取当前元素文本
+    const selectorPart = rule.replace(/@[^@]*$/, '').trim();
+    if (selectorPart) {
+      const child = el.find(selectorPart);
+      if (child.length) return child.first().text().trim();
+    }
+    return el.text().trim();
+  }
+
+  private getTextFromElement(el: cheerio.Cheerio<cheerio.Element>, rule: string): string {
+    return this.getStringFromElement(el, rule);
+  }
+
+  /** 获取 HTML 字符串（用于下一级规则） */
+  getHtml(rule?: string): string {
+    if (!rule) return this.$.html() ?? '';
+    const el = this.root.find(rule).first();
+    return el.html() ?? '';
+  }
+}

--- a/src/core/ruleEngine/AnalyzeByJSONPath.ts
+++ b/src/core/ruleEngine/AnalyzeByJSONPath.ts
@@ -1,0 +1,50 @@
+/**
+ * AnalyzeByJSONPath — JSONPath 解析器
+ * 对应 legado Android: AnalyzeByJSonPath.kt
+ * 使用 jsonpath-plus
+ */
+
+import { JSONPath } from 'jsonpath-plus';
+
+export class AnalyzeByJSONPath {
+  private data: unknown;
+
+  constructor(jsonOrObject: string | unknown) {
+    if (typeof jsonOrObject === 'string') {
+      try {
+        this.data = JSON.parse(jsonOrObject);
+      } catch {
+        this.data = jsonOrObject;
+      }
+    } else {
+      this.data = jsonOrObject;
+    }
+  }
+
+  /** 获取字符串列表 */
+  getStringList(rule: string): string[] {
+    try {
+      const result = JSONPath({ path: rule, json: this.data as object });
+      if (!Array.isArray(result)) return result != null ? [String(result)] : [];
+      return result.map((item) => (item != null ? String(item) : '')).filter(Boolean);
+    } catch {
+      return [];
+    }
+  }
+
+  /** 获取单个字符串 */
+  getString(rule: string): string {
+    return this.getStringList(rule)[0] ?? '';
+  }
+
+  /** 获取原始值（数组/对象，用于下一级规则） */
+  getObject(rule: string): unknown {
+    try {
+      const result = JSONPath({ path: rule, json: this.data as object });
+      if (Array.isArray(result) && result.length === 1) return result[0];
+      return result;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/core/ruleEngine/AnalyzeByRegex.ts
+++ b/src/core/ruleEngine/AnalyzeByRegex.ts
@@ -1,0 +1,53 @@
+/**
+ * AnalyzeByRegex — 正则规则
+ * 对应 legado 的 ##regex##replacement 后缀语法
+ */
+
+export class AnalyzeByRegex {
+  /**
+   * 应用正则替换
+   * @param src 输入字符串
+   * @param pattern 正则表达式字符串
+   * @param replacement 替换字符串（$1, $2 等反向引用）
+   */
+  static replace(src: string, pattern: string, replacement: string): string {
+    try {
+      const re = new RegExp(pattern, 'g');
+      return src.replace(re, replacement);
+    } catch {
+      return src;
+    }
+  }
+
+  /**
+   * 提取第一个匹配
+   * @param src 输入字符串
+   * @param pattern 正则
+   * @param groupIndex 捕获组索引，默认 0（整个匹配）
+   */
+  static match(src: string, pattern: string, groupIndex = 0): string {
+    try {
+      const re = new RegExp(pattern);
+      const m = src.match(re);
+      if (!m) return '';
+      return m[groupIndex] ?? '';
+    } catch {
+      return '';
+    }
+  }
+
+  /** 提取所有匹配列表 */
+  static matchAll(src: string, pattern: string, groupIndex = 0): string[] {
+    try {
+      const re = new RegExp(pattern, 'g');
+      const results: string[] = [];
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(src)) !== null) {
+        results.push(m[groupIndex] ?? m[0]);
+      }
+      return results;
+    } catch {
+      return [];
+    }
+  }
+}

--- a/src/core/ruleEngine/AnalyzeByXPath.ts
+++ b/src/core/ruleEngine/AnalyzeByXPath.ts
@@ -1,0 +1,79 @@
+/**
+ * AnalyzeByXPath — XPath 解析器
+ * 对应 legado Android: AnalyzeByXPath.kt
+ * 使用 xpath + xmldom
+ */
+
+import { DOMParser } from 'xmldom';
+import * as xpath from 'xpath';
+
+export class AnalyzeByXPath {
+  private doc: Document;
+
+  constructor(html: string) {
+    // xmldom DOMParser，容错模式
+    this.doc = new DOMParser({
+      locator: {},
+      errorHandler: { warning: () => {}, error: () => {}, fatalError: () => {} },
+    }).parseFromString(html, 'text/html');
+  }
+
+  /** 获取节点列表 */
+  getElements(xpathRule: string): Node[] {
+    try {
+      const result = xpath.evaluate(
+        xpathRule,
+        this.doc,
+        null,
+        xpath.XPathResult.ANY_TYPE,
+        null,
+      );
+      const nodes: Node[] = [];
+      if (result.resultType === xpath.XPathResult.STRING_TYPE) {
+        // 返回单个字符串时包装
+        return [];
+      }
+      let node = result.iterateNext();
+      while (node) {
+        nodes.push(node);
+        node = result.iterateNext();
+      }
+      return nodes;
+    } catch {
+      return [];
+    }
+  }
+
+  /** 获取字符串列表 */
+  getStringList(xpathRule: string): string[] {
+    try {
+      const result = xpath.evaluate(
+        xpathRule,
+        this.doc,
+        null,
+        xpath.XPathResult.ANY_TYPE,
+        null,
+      );
+      // 字符串结果
+      if (result.resultType === xpath.XPathResult.STRING_TYPE) {
+        const s = result.stringValue;
+        return s ? [s.trim()] : [];
+      }
+      const strings: string[] = [];
+      let node = result.iterateNext();
+      while (node) {
+        const text = node.textContent?.trim() ?? '';
+        if (text) strings.push(text);
+        node = result.iterateNext();
+      }
+      return strings;
+    } catch {
+      return [];
+    }
+  }
+
+  /** 获取单个字符串 */
+  getString(xpathRule: string): string {
+    return this.getStringList(xpathRule)[0] ?? '';
+  }
+}

--- a/src/core/ruleEngine/AnalyzeRule.ts
+++ b/src/core/ruleEngine/AnalyzeRule.ts
@@ -1,0 +1,139 @@
+/**
+ * AnalyzeRule — 主规则入口
+ * 对应 legado Android: AnalyzeRule.kt
+ *
+ * 根据规则字符串自动选择 CSS / XPath / JSONPath / Regex / JS 解析器，
+ * 支持多级规则（@ 连接）和候选规则（|| 分隔）。
+ */
+
+import { parseRule, parseSingleRule, splitByAt } from './RuleAnalyzer';
+import { AnalyzeByCSS } from './AnalyzeByCSS';
+import { AnalyzeByXPath } from './AnalyzeByXPath';
+import { AnalyzeByJSONPath } from './AnalyzeByJSONPath';
+import { AnalyzeByRegex } from './AnalyzeByRegex';
+import { JSEngine, JSContext } from './JSEngine';
+
+export class AnalyzeRule {
+  private content: unknown;
+  private baseUrl: string;
+  private jsContext: JSContext;
+
+  constructor(content: unknown, baseUrl = '', jsContext: JSContext = {}) {
+    this.content = content;
+    this.baseUrl = baseUrl;
+    this.jsContext = { ...jsContext, baseUrl };
+  }
+
+  setContent(content: unknown, baseUrl?: string) {
+    this.content = content;
+    if (baseUrl) this.baseUrl = baseUrl;
+    return this;
+  }
+
+  // ─── 公开接口 ────────────────────────────────────────────────
+
+  /** 获取单个字符串 */
+  getString(rule: string): string {
+    if (!rule?.trim()) return '';
+    return this.getStringList(rule)[0] ?? '';
+  }
+
+  /** 获取字符串列表 */
+  getStringList(rule: string): string[] {
+    if (!rule?.trim()) return [];
+
+    // || 候选：取第一个非空结果
+    const candidates = rule.split('||');
+    for (const candidate of candidates) {
+      try {
+        const result = this.evalCandidate(candidate.trim());
+        if (result.length > 0) return result;
+      } catch {
+        continue;
+      }
+    }
+    return [];
+  }
+
+  // ─── 私有实现 ─────────────────────────────────────────────────
+
+  private evalCandidate(rule: string): string[] {
+    // 按 @ 分割多级规则
+    const parts = splitByAt(rule);
+    let current: unknown = this.content;
+
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      const isLast = i === parts.length - 1;
+      current = this.evalSinglePart(part, current, isLast);
+    }
+
+    // 最终处理成字符串列表
+    return this.toStringList(current);
+  }
+
+  private evalSinglePart(rule: string, input: unknown, returnList: boolean): unknown {
+    const parsed = parseSingleRule(rule);
+    let result: unknown;
+
+    switch (parsed.type) {
+      case 'js': {
+        result = JSEngine.evalString(parsed.value, { ...this.jsContext, result: input });
+        break;
+      }
+      case 'xpath': {
+        const html = this.toHtml(input);
+        const analyzer = new AnalyzeByXPath(html);
+        result = returnList ? analyzer.getStringList(parsed.value) : analyzer.getString(parsed.value);
+        break;
+      }
+      case 'jsonpath': {
+        const analyzer = new AnalyzeByJSONPath(input);
+        result = returnList ? analyzer.getStringList(parsed.value) : analyzer.getString(parsed.value);
+        break;
+      }
+      case 'css':
+      case 'default': {
+        // 自动检测：如果 input 是 JSON，用 JSONPath 兜底
+        if (this.isJson(input)) {
+          const analyzer = new AnalyzeByJSONPath(input);
+          result = returnList ? analyzer.getStringList(parsed.value) : analyzer.getString(parsed.value);
+        } else {
+          const html = this.toHtml(input);
+          const analyzer = new AnalyzeByCSS(html);
+          result = returnList ? analyzer.getStringList(parsed.value) : analyzer.getString(parsed.value);
+        }
+        break;
+      }
+      default:
+        result = input;
+    }
+
+    // 应用 ##regex##replace 后缀
+    if (parsed.replaceRegex !== undefined) {
+      const str = Array.isArray(result) ? result.join('') : String(result ?? '');
+      result = AnalyzeByRegex.replace(str, parsed.replaceRegex, parsed.replaceWith ?? '');
+    }
+
+    return result;
+  }
+
+  private toStringList(value: unknown): string[] {
+    if (value === null || value === undefined) return [];
+    if (Array.isArray(value)) return value.map((v) => String(v ?? '')).filter(Boolean);
+    const s = String(value).trim();
+    return s ? [s] : [];
+  }
+
+  private toHtml(input: unknown): string {
+    if (typeof input === 'string') return input;
+    if (input === null || input === undefined) return '';
+    return String(input);
+  }
+
+  private isJson(input: unknown): boolean {
+    if (typeof input !== 'string') return typeof input === 'object';
+    const s = input.trim();
+    return s.startsWith('{') || s.startsWith('[');
+  }
+}

--- a/src/core/ruleEngine/JSEngine.ts
+++ b/src/core/ruleEngine/JSEngine.ts
@@ -1,0 +1,82 @@
+/**
+ * JSEngine — 书源 JS 规则执行引擎
+ * 对应 legado Android: RhinoScriptEngine (Rhino JS)
+ *
+ * React Native 中 JS 运行在同一 JS 引擎（Hermes/V8），
+ * 直接用 Function 构造器实现 eval 沙箱，无需额外依赖。
+ *
+ * 书源 JS 中常用的 java 对象在 legado 里由 JsExtensions 提供，
+ * 这里实现对应的 JS 替代品注入到沙箱 context。
+ */
+
+export interface JSContext {
+  result?: unknown;
+  baseUrl?: string;
+  chapter?: Record<string, unknown>;
+  book?: Record<string, unknown>;
+  source?: Record<string, unknown>;
+  /** 页码 */
+  page?: number;
+  /** 搜索关键字 */
+  key?: string;
+}
+
+/** 注入到书源 JS 沙箱的工具函数 */
+const JS_EXTENSIONS = `
+// legado JsExtensions 的 JS 等价实现
+const java = {
+  encodeBase64: (s) => btoa(unescape(encodeURIComponent(s))),
+  decodeBase64: (s) => decodeURIComponent(escape(atob(s))),
+  encodeUrl: (s) => encodeURIComponent(s),
+  decodeUrl: (s) => decodeURIComponent(s),
+  md5: () => '',  // placeholder
+};
+
+const base64Encode = (s) => java.encodeBase64(s);
+const base64Decode = (s) => java.decodeBase64(s);
+const encodeUrl = (s) => java.encodeUrl(s);
+const decodeUrl = (s) => java.decodeUrl(s);
+
+// 简单的 log
+const log = (...args) => console.log('[JSEngine]', ...args);
+`;
+
+export class JSEngine {
+  /**
+   * 执行书源 JS 规则
+   * @param code JS 代码字符串
+   * @param context 注入的上下文变量（result, baseUrl, page, key 等）
+   * @returns JS 执行结果
+   */
+  static eval(code: string, context: JSContext = {}): unknown {
+    try {
+      // 构建参数列表：注入 context 中所有变量
+      const keys = Object.keys(context);
+      const values = Object.values(context);
+
+      const wrappedCode = `
+${JS_EXTENSIONS}
+${keys.map((k) => `var ${k} = __ctx__["${k}"];`).join('\n')}
+${code}
+`;
+      // eslint-disable-next-line no-new-func
+      const fn = new Function('__ctx__', wrappedCode);
+      const result = fn({ ...context });
+      // 如果代码没有显式 return，尝试取 result 变量
+      return result !== undefined ? result : context.result;
+    } catch (e) {
+      console.warn('[JSEngine] eval error:', e);
+      return context.result ?? '';
+    }
+  }
+
+  /**
+   * 执行并确保返回字符串
+   */
+  static evalString(code: string, context: JSContext = {}): string {
+    const result = JSEngine.eval(code, context);
+    if (result === null || result === undefined) return '';
+    if (typeof result === 'object') return JSON.stringify(result);
+    return String(result);
+  }
+}

--- a/src/core/ruleEngine/index.ts
+++ b/src/core/ruleEngine/index.ts
@@ -1,0 +1,9 @@
+export { RuleAnalyzer, parseRule, parseSingleRule, splitByAt } from './RuleAnalyzer';
+export type { ParsedRule, RuleSegment } from './RuleAnalyzer';
+export { AnalyzeByCSS } from './AnalyzeByCSS';
+export { AnalyzeByXPath } from './AnalyzeByXPath';
+export { AnalyzeByJSONPath } from './AnalyzeByJSONPath';
+export { AnalyzeByRegex } from './AnalyzeByRegex';
+export { JSEngine } from './JSEngine';
+export type { JSContext } from './JSEngine';
+export { AnalyzeRule } from './AnalyzeRule';

--- a/src/data/dao/BookChapterDao.ts
+++ b/src/data/dao/BookChapterDao.ts
@@ -1,0 +1,79 @@
+/**
+ * BookChapterDao — 章节数据访问层
+ */
+
+import { getDatabase } from '../database/AppDatabase';
+import { BookChapter } from '../models/BookChapter';
+
+function rowToChapter(row: Record<string, unknown>): BookChapter {
+  return {
+    url: row.url as string,
+    title: (row.title as string) ?? '',
+    bookUrl: row.bookUrl as string,
+    index: (row.idx as number) ?? 0,
+    resourceUrl: (row.resourceUrl as string) ?? undefined,
+    tag: (row.tag as string) ?? undefined,
+    start: (row.start as number) ?? undefined,
+    end: (row.end as number) ?? undefined,
+    isVolume: (row.isVolume as number) === 1,
+    isVip: (row.isVip as number) === 1,
+    isPay: (row.isPay as number) === 1,
+    updateTime: (row.updateTime as string) ?? undefined,
+    variable: (row.variable as string) ?? undefined,
+  };
+}
+
+export const BookChapterDao = {
+  async getByBook(bookUrl: string): Promise<BookChapter[]> {
+    const db = await getDatabase();
+    const rows = await db.getAllAsync<Record<string, unknown>>(
+      'SELECT * FROM book_chapters WHERE bookUrl = ? ORDER BY idx ASC',
+      [bookUrl],
+    );
+    return rows.map(rowToChapter);
+  },
+
+  async getByIndex(bookUrl: string, index: number): Promise<BookChapter | null> {
+    const db = await getDatabase();
+    const row = await db.getFirstAsync<Record<string, unknown>>(
+      'SELECT * FROM book_chapters WHERE bookUrl = ? AND idx = ?',
+      [bookUrl, index],
+    );
+    return row ? rowToChapter(row) : null;
+  },
+
+  async upsertMany(chapters: BookChapter[]): Promise<void> {
+    const db = await getDatabase();
+    await db.withTransactionAsync(async () => {
+      for (const ch of chapters) {
+        await db.runAsync(
+          `INSERT OR REPLACE INTO book_chapters
+            (url, bookUrl, title, idx, resourceUrl, tag, start, end,
+             isVolume, isVip, isPay, updateTime, variable)
+           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+          [
+            ch.url, ch.bookUrl, ch.title, ch.index,
+            ch.resourceUrl ?? null, ch.tag ?? null,
+            ch.start ?? null, ch.end ?? null,
+            ch.isVolume ? 1 : 0, ch.isVip ? 1 : 0, ch.isPay ? 1 : 0,
+            ch.updateTime ?? null, ch.variable ?? null,
+          ],
+        );
+      }
+    });
+  },
+
+  async deleteByBook(bookUrl: string): Promise<void> {
+    const db = await getDatabase();
+    await db.runAsync('DELETE FROM book_chapters WHERE bookUrl = ?', [bookUrl]);
+  },
+
+  async count(bookUrl: string): Promise<number> {
+    const db = await getDatabase();
+    const row = await db.getFirstAsync<{ cnt: number }>(
+      'SELECT COUNT(*) as cnt FROM book_chapters WHERE bookUrl = ?',
+      [bookUrl],
+    );
+    return row?.cnt ?? 0;
+  },
+};

--- a/src/data/dao/BookDao.ts
+++ b/src/data/dao/BookDao.ts
@@ -1,0 +1,132 @@
+/**
+ * BookDao — 书籍数据访问层
+ */
+
+import { getDatabase } from '../database/AppDatabase';
+import { Book } from '../models/Book';
+
+function rowToBook(row: Record<string, unknown>): Book {
+  return {
+    bookUrl: row.bookUrl as string,
+    tocUrl: (row.tocUrl as string) ?? '',
+    origin: (row.origin as string) ?? '',
+    originName: (row.originName as string) ?? '',
+    name: (row.name as string) ?? '',
+    author: (row.author as string) ?? '',
+    kind: (row.kind as string) ?? undefined,
+    customTag: (row.customTag as string) ?? undefined,
+    coverUrl: (row.coverUrl as string) ?? undefined,
+    customCoverUrl: (row.customCoverUrl as string) ?? undefined,
+    intro: (row.intro as string) ?? undefined,
+    customIntro: (row.customIntro as string) ?? undefined,
+    charset: (row.charset as string) ?? undefined,
+    type: (row.type as number) ?? 0,
+    group: (row.bookGroup as number) ?? 0,
+    latestChapterTitle: (row.latestChapterTitle as string) ?? undefined,
+    latestChapterTime: (row.latestChapterTime as number) ?? 0,
+    lastCheckTime: (row.lastCheckTime as number) ?? 0,
+    lastCheckCount: (row.lastCheckCount as number) ?? 0,
+    totalChapterNum: (row.totalChapterNum as number) ?? 0,
+    scrollIndex: (row.scrollIndex as number) ?? 0,
+    durChapterIndex: (row.durChapterIndex as number) ?? 0,
+    durChapterPos: (row.durChapterPos as number) ?? 0,
+    durChapterTime: (row.durChapterTime as number) ?? 0,
+    wordCount: (row.wordCount as string) ?? undefined,
+    canUpdate: (row.canUpdate as number) === 1,
+    order: (row.bookOrder as number) ?? 0,
+    useReplaceRule: row.useReplaceRule != null ? (row.useReplaceRule as number) === 1 : undefined,
+    hasImageContent: row.hasImageContent != null ? (row.hasImageContent as number) === 1 : undefined,
+    variable: (row.variable as string) ?? undefined,
+  };
+}
+
+export const BookDao = {
+  async getAll(): Promise<Book[]> {
+    const db = await getDatabase();
+    const rows = await db.getAllAsync<Record<string, unknown>>(
+      'SELECT * FROM books ORDER BY bookOrder ASC, name ASC',
+    );
+    return rows.map(rowToBook);
+  },
+
+  async getByGroup(groupId: number): Promise<Book[]> {
+    const db = await getDatabase();
+    let rows: Record<string, unknown>[];
+    if (groupId === -1) {
+      // 全部
+      rows = await db.getAllAsync<Record<string, unknown>>(
+        'SELECT * FROM books ORDER BY bookOrder ASC',
+      );
+    } else if (groupId === -2) {
+      // 本地
+      rows = await db.getAllAsync<Record<string, unknown>>(
+        "SELECT * FROM books WHERE origin = 'local' ORDER BY bookOrder ASC",
+      );
+    } else if (groupId === -3) {
+      // 音频
+      rows = await db.getAllAsync<Record<string, unknown>>(
+        'SELECT * FROM books WHERE type = 1 ORDER BY bookOrder ASC',
+      );
+    } else if (groupId === -4) {
+      // 未分组
+      rows = await db.getAllAsync<Record<string, unknown>>(
+        'SELECT * FROM books WHERE bookGroup = 0 ORDER BY bookOrder ASC',
+      );
+    } else {
+      rows = await db.getAllAsync<Record<string, unknown>>(
+        'SELECT * FROM books WHERE (bookGroup & ?) != 0 ORDER BY bookOrder ASC',
+        [groupId],
+      );
+    }
+    return rows.map(rowToBook);
+  },
+
+  async getByUrl(url: string): Promise<Book | null> {
+    const db = await getDatabase();
+    const row = await db.getFirstAsync<Record<string, unknown>>(
+      'SELECT * FROM books WHERE bookUrl = ?',
+      [url],
+    );
+    return row ? rowToBook(row) : null;
+  },
+
+  async upsert(book: Book): Promise<void> {
+    const db = await getDatabase();
+    await db.runAsync(
+      `INSERT OR REPLACE INTO books
+        (bookUrl, tocUrl, origin, originName, name, author, kind, customTag,
+         coverUrl, customCoverUrl, intro, customIntro, charset, type, bookGroup,
+         latestChapterTitle, latestChapterTime, lastCheckTime, lastCheckCount,
+         totalChapterNum, scrollIndex, durChapterIndex, durChapterPos, durChapterTime,
+         wordCount, canUpdate, bookOrder, useReplaceRule, hasImageContent, variable)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+      [
+        book.bookUrl, book.tocUrl, book.origin, book.originName,
+        book.name, book.author, book.kind ?? null, book.customTag ?? null,
+        book.coverUrl ?? null, book.customCoverUrl ?? null,
+        book.intro ?? null, book.customIntro ?? null, book.charset ?? null,
+        book.type, book.group,
+        book.latestChapterTitle ?? null, book.latestChapterTime,
+        book.lastCheckTime, book.lastCheckCount, book.totalChapterNum,
+        book.scrollIndex, book.durChapterIndex, book.durChapterPos, book.durChapterTime,
+        book.wordCount ?? null, book.canUpdate ? 1 : 0, book.order,
+        book.useReplaceRule != null ? (book.useReplaceRule ? 1 : 0) : null,
+        book.hasImageContent != null ? (book.hasImageContent ? 1 : 0) : null,
+        book.variable ?? null,
+      ],
+    );
+  },
+
+  async updateProgress(bookUrl: string, chapterIndex: number, chapterPos: number): Promise<void> {
+    const db = await getDatabase();
+    await db.runAsync(
+      'UPDATE books SET durChapterIndex = ?, durChapterPos = ?, durChapterTime = ? WHERE bookUrl = ?',
+      [chapterIndex, chapterPos, Date.now(), bookUrl],
+    );
+  },
+
+  async delete(bookUrl: string): Promise<void> {
+    const db = await getDatabase();
+    await db.runAsync('DELETE FROM books WHERE bookUrl = ?', [bookUrl]);
+  },
+};

--- a/src/data/dao/BookGroupDao.ts
+++ b/src/data/dao/BookGroupDao.ts
@@ -1,0 +1,38 @@
+/**
+ * BookGroupDao
+ */
+import { getDatabase } from '../database/AppDatabase';
+import { BookGroup } from '../models/BookGroup';
+
+function rowToGroup(row: Record<string, unknown>): BookGroup {
+  return {
+    groupId: row.groupId as number,
+    groupName: row.groupName as string,
+    order: row.groupOrder as number,
+    show: (row.show as number) === 1,
+  };
+}
+
+export const BookGroupDao = {
+  async getAll(): Promise<BookGroup[]> {
+    const db = await getDatabase();
+    const rows = await db.getAllAsync<Record<string, unknown>>(
+      'SELECT * FROM book_groups ORDER BY groupOrder ASC',
+    );
+    return rows.map(rowToGroup);
+  },
+
+  async upsert(group: BookGroup): Promise<void> {
+    const db = await getDatabase();
+    await db.runAsync(
+      `INSERT OR REPLACE INTO book_groups (groupId, groupName, groupOrder, show)
+       VALUES (?,?,?,?)`,
+      [group.groupId, group.groupName, group.order, group.show ? 1 : 0],
+    );
+  },
+
+  async delete(groupId: number): Promise<void> {
+    const db = await getDatabase();
+    await db.runAsync('DELETE FROM book_groups WHERE groupId = ?', [groupId]);
+  },
+};

--- a/src/data/dao/BookSourceDao.ts
+++ b/src/data/dao/BookSourceDao.ts
@@ -1,0 +1,139 @@
+/**
+ * BookSourceDao — 书源数据访问层
+ */
+
+import { getDatabase } from '../database/AppDatabase';
+import { BookSource } from '../models/BookSource';
+
+function rowToBookSource(row: Record<string, unknown>): BookSource {
+  const parse = (v: unknown) => {
+    if (!v || typeof v !== 'string') return undefined;
+    try { return JSON.parse(v); } catch { return undefined; }
+  };
+  return {
+    bookSourceUrl: row.bookSourceUrl as string,
+    bookSourceName: row.bookSourceName as string,
+    bookSourceGroup: (row.bookSourceGroup as string) ?? undefined,
+    bookSourceType: (row.bookSourceType as number) ?? 0,
+    bookUrlPattern: (row.bookUrlPattern as string) ?? undefined,
+    customOrder: (row.customOrder as number) ?? 0,
+    enabled: (row.enabled as number) === 1,
+    enabledExplore: (row.enabledExplore as number) === 1,
+    enabledCookieJar: row.enabledCookieJar != null ? (row.enabledCookieJar as number) === 1 : undefined,
+    concurrentRate: (row.concurrentRate as string) ?? undefined,
+    header: (row.header as string) ?? undefined,
+    loginUrl: (row.loginUrl as string) ?? undefined,
+    loginUi: (row.loginUi as string) ?? undefined,
+    loginCheckJs: (row.loginCheckJs as string) ?? undefined,
+    coverDecodeJs: (row.coverDecodeJs as string) ?? undefined,
+    jsLib: (row.jsLib as string) ?? undefined,
+    bookSourceComment: (row.bookSourceComment as string) ?? undefined,
+    lastUpdateTime: (row.lastUpdateTime as number) ?? 0,
+    respondTime: (row.respondTime as number) ?? 180000,
+    weight: (row.weight as number) ?? 0,
+    exploreUrl: (row.exploreUrl as string) ?? undefined,
+    searchUrl: (row.searchUrl as string) ?? undefined,
+    ruleExplore: parse(row.ruleExplore),
+    ruleSearch: parse(row.ruleSearch),
+    ruleBookInfo: parse(row.ruleBookInfo),
+    ruleToc: parse(row.ruleToc),
+    ruleContent: parse(row.ruleContent),
+  };
+}
+
+export const BookSourceDao = {
+  async getAll(): Promise<BookSource[]> {
+    const db = await getDatabase();
+    const rows = await db.getAllAsync<Record<string, unknown>>(
+      'SELECT * FROM book_sources ORDER BY customOrder ASC, bookSourceName ASC',
+    );
+    return rows.map(rowToBookSource);
+  },
+
+  async getEnabled(): Promise<BookSource[]> {
+    const db = await getDatabase();
+    const rows = await db.getAllAsync<Record<string, unknown>>(
+      'SELECT * FROM book_sources WHERE enabled = 1 ORDER BY weight DESC, customOrder ASC',
+    );
+    return rows.map(rowToBookSource);
+  },
+
+  async getByUrl(url: string): Promise<BookSource | null> {
+    const db = await getDatabase();
+    const row = await db.getFirstAsync<Record<string, unknown>>(
+      'SELECT * FROM book_sources WHERE bookSourceUrl = ?',
+      [url],
+    );
+    return row ? rowToBookSource(row) : null;
+  },
+
+  async upsert(source: BookSource): Promise<void> {
+    const db = await getDatabase();
+    await db.runAsync(
+      `INSERT OR REPLACE INTO book_sources
+        (bookSourceUrl, bookSourceName, bookSourceGroup, bookSourceType,
+         bookUrlPattern, customOrder, enabled, enabledExplore, enabledCookieJar,
+         concurrentRate, header, loginUrl, loginUi, loginCheckJs, coverDecodeJs,
+         jsLib, bookSourceComment, lastUpdateTime, respondTime, weight,
+         exploreUrl, searchUrl, ruleExplore, ruleSearch, ruleBookInfo, ruleToc, ruleContent)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+      [
+        source.bookSourceUrl,
+        source.bookSourceName,
+        source.bookSourceGroup ?? null,
+        source.bookSourceType,
+        source.bookUrlPattern ?? null,
+        source.customOrder,
+        source.enabled ? 1 : 0,
+        source.enabledExplore ? 1 : 0,
+        source.enabledCookieJar != null ? (source.enabledCookieJar ? 1 : 0) : null,
+        source.concurrentRate ?? null,
+        source.header ?? null,
+        source.loginUrl ?? null,
+        source.loginUi ?? null,
+        source.loginCheckJs ?? null,
+        source.coverDecodeJs ?? null,
+        source.jsLib ?? null,
+        source.bookSourceComment ?? null,
+        source.lastUpdateTime,
+        source.respondTime,
+        source.weight,
+        source.exploreUrl ?? null,
+        source.searchUrl ?? null,
+        source.ruleExplore ? JSON.stringify(source.ruleExplore) : null,
+        source.ruleSearch ? JSON.stringify(source.ruleSearch) : null,
+        source.ruleBookInfo ? JSON.stringify(source.ruleBookInfo) : null,
+        source.ruleToc ? JSON.stringify(source.ruleToc) : null,
+        source.ruleContent ? JSON.stringify(source.ruleContent) : null,
+      ],
+    );
+  },
+
+  /** 批量导入（书源 JSON 数组） */
+  async importMany(sources: BookSource[]): Promise<{ success: number; failed: number }> {
+    let success = 0;
+    let failed = 0;
+    for (const s of sources) {
+      try {
+        await BookSourceDao.upsert(s);
+        success++;
+      } catch {
+        failed++;
+      }
+    }
+    return { success, failed };
+  },
+
+  async delete(url: string): Promise<void> {
+    const db = await getDatabase();
+    await db.runAsync('DELETE FROM book_sources WHERE bookSourceUrl = ?', [url]);
+  },
+
+  async setEnabled(url: string, enabled: boolean): Promise<void> {
+    const db = await getDatabase();
+    await db.runAsync(
+      'UPDATE book_sources SET enabled = ? WHERE bookSourceUrl = ?',
+      [enabled ? 1 : 0, url],
+    );
+  },
+};

--- a/src/data/dao/RssSourceDao.ts
+++ b/src/data/dao/RssSourceDao.ts
@@ -1,0 +1,123 @@
+/**
+ * RssSourceDao — CRUD for rss_sources table
+ */
+
+import { getDatabase } from '../database/AppDatabase';
+import { RssSource } from '../models/RssSource';
+
+function rowToSource(row: Record<string, unknown>): RssSource {
+  return {
+    sourceUrl: row.sourceUrl as string,
+    sourceName: row.sourceName as string,
+    sourceGroup: (row.sourceGroup as string) || undefined,
+    sourceIcon: (row.sourceIcon as string) || undefined,
+    sourceComment: (row.sourceComment as string) || undefined,
+    enabled: (row.enabled as number) === 1,
+    enabledCookieJar: row.enabledCookieJar != null ? (row.enabledCookieJar as number) === 1 : undefined,
+    enableJs: row.enableJs != null ? (row.enableJs as number) === 1 : undefined,
+    loadWithBaseUrl: row.loadWithBaseUrl != null ? (row.loadWithBaseUrl as number) === 1 : undefined,
+    articleStyle: row.articleStyle as number,
+    concurrentRate: (row.concurrentRate as string) || undefined,
+    header: (row.header as string) || undefined,
+    loginUrl: (row.loginUrl as string) || undefined,
+    loginUi: (row.loginUi as string) || undefined,
+    loginCheckJs: (row.loginCheckJs as string) || undefined,
+    jsLib: (row.jsLib as string) || undefined,
+    injectJs: (row.injectJs as string) || undefined,
+    shouldOverrideUrlLoading: (row.shouldOverrideUrlLoading as string) || undefined,
+    sortUrl: (row.sortUrl as string) || undefined,
+    singleUrl: (row.singleUrl as number) === 1,
+    customOrder: row.customOrder as number,
+    ruleArticles: (row.ruleArticles as string) || undefined,
+    ruleNextPage: (row.ruleNextPage as string) || undefined,
+    ruleTitle: (row.ruleTitle as string) || undefined,
+    rulePubDate: (row.rulePubDate as string) || undefined,
+    ruleImage: (row.ruleImage as string) || undefined,
+    ruleLink: (row.ruleLink as string) || undefined,
+    ruleContent: (row.ruleContent as string) || undefined,
+    style: (row.style as string) || undefined,
+    webCss: (row.webCss as string) || undefined,
+    lastUpdateTime: row.lastUpdateTime as number,
+  };
+}
+
+export class RssSourceDao {
+  static async getAll(): Promise<RssSource[]> {
+    const db = await getDatabase();
+    const rows = await db.getAllAsync<Record<string, unknown>>(
+      'SELECT * FROM rss_sources ORDER BY customOrder ASC, sourceName ASC'
+    );
+    return rows.map(rowToSource);
+  }
+
+  static async getEnabled(): Promise<RssSource[]> {
+    const db = await getDatabase();
+    const rows = await db.getAllAsync<Record<string, unknown>>(
+      'SELECT * FROM rss_sources WHERE enabled = 1 ORDER BY customOrder ASC, sourceName ASC'
+    );
+    return rows.map(rowToSource);
+  }
+
+  static async getByUrl(sourceUrl: string): Promise<RssSource | null> {
+    const db = await getDatabase();
+    const row = await db.getFirstAsync<Record<string, unknown>>(
+      'SELECT * FROM rss_sources WHERE sourceUrl = ?', [sourceUrl]
+    );
+    return row ? rowToSource(row) : null;
+  }
+
+  static async upsert(source: RssSource): Promise<void> {
+    const db = await getDatabase();
+    await db.runAsync(
+      `INSERT OR REPLACE INTO rss_sources
+        (sourceUrl, sourceName, sourceGroup, sourceIcon, sourceComment,
+         enabled, enabledCookieJar, enableJs, loadWithBaseUrl, articleStyle,
+         concurrentRate, header, loginUrl, loginUi, loginCheckJs, jsLib,
+         injectJs, shouldOverrideUrlLoading, sortUrl, singleUrl, customOrder,
+         ruleArticles, ruleNextPage, ruleTitle, rulePubDate, ruleImage,
+         ruleLink, ruleContent, style, webCss, lastUpdateTime)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+      [
+        source.sourceUrl, source.sourceName, source.sourceGroup ?? null,
+        source.sourceIcon ?? null, source.sourceComment ?? null,
+        source.enabled ? 1 : 0,
+        source.enabledCookieJar != null ? (source.enabledCookieJar ? 1 : 0) : null,
+        source.enableJs != null ? (source.enableJs ? 1 : 0) : null,
+        source.loadWithBaseUrl != null ? (source.loadWithBaseUrl ? 1 : 0) : null,
+        source.articleStyle ?? 0,
+        source.concurrentRate ?? null, source.header ?? null,
+        source.loginUrl ?? null, source.loginUi ?? null, source.loginCheckJs ?? null,
+        source.jsLib ?? null, source.injectJs ?? null,
+        source.shouldOverrideUrlLoading ?? null, source.sortUrl ?? null,
+        source.singleUrl ? 1 : 0, source.customOrder ?? 0,
+        source.ruleArticles ?? null, source.ruleNextPage ?? null,
+        source.ruleTitle ?? null, source.rulePubDate ?? null,
+        source.ruleImage ?? null, source.ruleLink ?? null,
+        source.ruleContent ?? null, source.style ?? null, source.webCss ?? null,
+        source.lastUpdateTime,
+      ]
+    );
+  }
+
+  static async importMany(sources: RssSource[]): Promise<void> {
+    for (const s of sources) {
+      await RssSourceDao.upsert(s);
+    }
+  }
+
+  static async setEnabled(sourceUrl: string, enabled: boolean): Promise<void> {
+    const db = await getDatabase();
+    await db.runAsync('UPDATE rss_sources SET enabled = ? WHERE sourceUrl = ?', [enabled ? 1 : 0, sourceUrl]);
+  }
+
+  static async delete(sourceUrl: string): Promise<void> {
+    const db = await getDatabase();
+    await db.runAsync('DELETE FROM rss_sources WHERE sourceUrl = ?', [sourceUrl]);
+  }
+
+  static async count(): Promise<number> {
+    const db = await getDatabase();
+    const row = await db.getFirstAsync<{ cnt: number }>('SELECT COUNT(*) as cnt FROM rss_sources');
+    return row?.cnt ?? 0;
+  }
+}

--- a/src/data/dao/index.ts
+++ b/src/data/dao/index.ts
@@ -1,0 +1,3 @@
+export { BookSourceDao } from './BookSourceDao';
+export { BookDao } from './BookDao';
+export { BookChapterDao } from './BookChapterDao';

--- a/src/data/dao/index.ts
+++ b/src/data/dao/index.ts
@@ -1,3 +1,5 @@
 export { BookSourceDao } from './BookSourceDao';
 export { BookDao } from './BookDao';
 export { BookChapterDao } from './BookChapterDao';
+export { BookGroupDao } from './BookGroupDao';
+export { RssSourceDao } from './RssSourceDao';

--- a/src/data/database/AppDatabase.ts
+++ b/src/data/database/AppDatabase.ts
@@ -145,6 +145,43 @@ async function initSchema(db: SQLite.SQLiteDatabase): Promise<void> {
     );
   `);
 
+  // rss_sources
+  await db.execAsync(`
+    CREATE TABLE IF NOT EXISTS rss_sources (
+      sourceUrl               TEXT PRIMARY KEY NOT NULL,
+      sourceName              TEXT NOT NULL DEFAULT '',
+      sourceGroup             TEXT,
+      sourceIcon              TEXT,
+      sourceComment           TEXT,
+      enabled                 INTEGER NOT NULL DEFAULT 1,
+      enabledCookieJar        INTEGER DEFAULT 0,
+      enableJs                INTEGER DEFAULT 1,
+      loadWithBaseUrl         INTEGER DEFAULT 0,
+      articleStyle            INTEGER NOT NULL DEFAULT 0,
+      concurrentRate          TEXT,
+      header                  TEXT,
+      loginUrl                TEXT,
+      loginUi                 TEXT,
+      loginCheckJs            TEXT,
+      jsLib                   TEXT,
+      injectJs                TEXT,
+      shouldOverrideUrlLoading TEXT,
+      sortUrl                 TEXT,
+      singleUrl               INTEGER NOT NULL DEFAULT 0,
+      customOrder             INTEGER NOT NULL DEFAULT 0,
+      ruleArticles            TEXT,
+      ruleNextPage            TEXT,
+      ruleTitle               TEXT,
+      rulePubDate             TEXT,
+      ruleImage               TEXT,
+      ruleLink                TEXT,
+      ruleContent             TEXT,
+      style                   TEXT,
+      webCss                  TEXT,
+      lastUpdateTime          INTEGER NOT NULL DEFAULT 0
+    );
+  `);
+
   // read_config
   await db.execAsync(`
     CREATE TABLE IF NOT EXISTS read_config (

--- a/src/data/database/AppDatabase.ts
+++ b/src/data/database/AppDatabase.ts
@@ -1,0 +1,176 @@
+/**
+ * AppDatabase — SQLite 数据库初始化与 migration
+ * 使用 expo-sqlite
+ */
+
+import * as SQLite from 'expo-sqlite';
+
+export const DB_NAME = 'legado.db';
+export const DB_VERSION = 1;
+
+let _db: SQLite.SQLiteDatabase | null = null;
+
+export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
+  if (_db) return _db;
+  _db = await SQLite.openDatabaseAsync(DB_NAME);
+  await initSchema(_db);
+  return _db;
+}
+
+async function initSchema(db: SQLite.SQLiteDatabase): Promise<void> {
+  await db.execAsync(`PRAGMA journal_mode = WAL;`);
+  await db.execAsync(`PRAGMA foreign_keys = ON;`);
+
+  // book_sources
+  await db.execAsync(`
+    CREATE TABLE IF NOT EXISTS book_sources (
+      bookSourceUrl     TEXT PRIMARY KEY NOT NULL,
+      bookSourceName    TEXT NOT NULL DEFAULT '',
+      bookSourceGroup   TEXT,
+      bookSourceType    INTEGER NOT NULL DEFAULT 0,
+      bookUrlPattern    TEXT,
+      customOrder       INTEGER NOT NULL DEFAULT 0,
+      enabled           INTEGER NOT NULL DEFAULT 1,
+      enabledExplore    INTEGER NOT NULL DEFAULT 1,
+      enabledCookieJar  INTEGER DEFAULT 1,
+      concurrentRate    TEXT,
+      header            TEXT,
+      loginUrl          TEXT,
+      loginUi           TEXT,
+      loginCheckJs      TEXT,
+      coverDecodeJs     TEXT,
+      jsLib             TEXT,
+      bookSourceComment TEXT,
+      lastUpdateTime    INTEGER NOT NULL DEFAULT 0,
+      respondTime       INTEGER NOT NULL DEFAULT 180000,
+      weight            INTEGER NOT NULL DEFAULT 0,
+      exploreUrl        TEXT,
+      searchUrl         TEXT,
+      ruleExplore       TEXT,
+      ruleSearch        TEXT,
+      ruleBookInfo      TEXT,
+      ruleToc           TEXT,
+      ruleContent       TEXT
+    );
+  `);
+
+  // books
+  await db.execAsync(`
+    CREATE TABLE IF NOT EXISTS books (
+      bookUrl            TEXT PRIMARY KEY NOT NULL,
+      tocUrl             TEXT NOT NULL DEFAULT '',
+      origin             TEXT NOT NULL DEFAULT '',
+      originName         TEXT NOT NULL DEFAULT '',
+      name               TEXT NOT NULL DEFAULT '',
+      author             TEXT NOT NULL DEFAULT '',
+      kind               TEXT,
+      customTag          TEXT,
+      coverUrl           TEXT,
+      customCoverUrl     TEXT,
+      intro              TEXT,
+      customIntro        TEXT,
+      charset            TEXT,
+      type               INTEGER NOT NULL DEFAULT 0,
+      bookGroup          INTEGER NOT NULL DEFAULT 0,
+      latestChapterTitle TEXT,
+      latestChapterTime  INTEGER NOT NULL DEFAULT 0,
+      lastCheckTime      INTEGER NOT NULL DEFAULT 0,
+      lastCheckCount     INTEGER NOT NULL DEFAULT 0,
+      totalChapterNum    INTEGER NOT NULL DEFAULT 0,
+      scrollIndex        INTEGER NOT NULL DEFAULT 0,
+      durChapterIndex    INTEGER NOT NULL DEFAULT 0,
+      durChapterPos      INTEGER NOT NULL DEFAULT 0,
+      durChapterTime     INTEGER NOT NULL DEFAULT 0,
+      wordCount          TEXT,
+      canUpdate          INTEGER NOT NULL DEFAULT 1,
+      bookOrder          INTEGER NOT NULL DEFAULT 0,
+      useReplaceRule     INTEGER,
+      hasImageContent    INTEGER,
+      variable           TEXT
+    );
+  `);
+
+  // book_chapters
+  await db.execAsync(`
+    CREATE TABLE IF NOT EXISTS book_chapters (
+      url             TEXT NOT NULL,
+      bookUrl         TEXT NOT NULL,
+      title           TEXT NOT NULL DEFAULT '',
+      idx             INTEGER NOT NULL DEFAULT 0,
+      resourceUrl     TEXT,
+      tag             TEXT,
+      start           INTEGER,
+      end             INTEGER,
+      isVolume        INTEGER NOT NULL DEFAULT 0,
+      isVip           INTEGER NOT NULL DEFAULT 0,
+      isPay           INTEGER NOT NULL DEFAULT 0,
+      updateTime      TEXT,
+      variable        TEXT,
+      PRIMARY KEY (url, bookUrl),
+      FOREIGN KEY (bookUrl) REFERENCES books(bookUrl) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_chapters_bookUrl ON book_chapters(bookUrl);
+  `);
+
+  // book_groups
+  await db.execAsync(`
+    CREATE TABLE IF NOT EXISTS book_groups (
+      groupId   INTEGER PRIMARY KEY NOT NULL,
+      groupName TEXT NOT NULL DEFAULT '',
+      groupOrder INTEGER NOT NULL DEFAULT 0,
+      show      INTEGER NOT NULL DEFAULT 1
+    );
+    INSERT OR IGNORE INTO book_groups (groupId, groupName, groupOrder, show)
+    VALUES (-1, '全部', -10, 1),
+           (-2, '本地', -9, 1),
+           (-3, '音频', -8, 1),
+           (-4, '未分组', -7, 1);
+  `);
+
+  // replace_rules
+  await db.execAsync(`
+    CREATE TABLE IF NOT EXISTS replace_rules (
+      id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+      name                TEXT NOT NULL DEFAULT '',
+      ruleGroup           TEXT,
+      pattern             TEXT NOT NULL DEFAULT '',
+      replacement         TEXT NOT NULL DEFAULT '',
+      isRegex             INTEGER NOT NULL DEFAULT 0,
+      scope               TEXT,
+      scopeTitle          INTEGER,
+      scopeContent        INTEGER,
+      timeoutMillisecond  INTEGER,
+      enabled             INTEGER NOT NULL DEFAULT 1,
+      ruleOrder           INTEGER NOT NULL DEFAULT 0
+    );
+  `);
+
+  // read_config
+  await db.execAsync(`
+    CREATE TABLE IF NOT EXISTS read_config (
+      id              INTEGER PRIMARY KEY NOT NULL,
+      name            TEXT NOT NULL DEFAULT '默认',
+      bgStr           TEXT,
+      bgStrNight      TEXT,
+      bgType          INTEGER NOT NULL DEFAULT 0,
+      bgTypeNight     INTEGER NOT NULL DEFAULT 0,
+      textColor       TEXT NOT NULL DEFAULT '#333333',
+      textColorNight  TEXT NOT NULL DEFAULT '#AAAAAA',
+      textSize        INTEGER NOT NULL DEFAULT 18,
+      letterSpacing   REAL NOT NULL DEFAULT 0,
+      lineSpacingExtra REAL NOT NULL DEFAULT 12,
+      paraSpacing     REAL NOT NULL DEFAULT 16,
+      fontPath        TEXT,
+      fontName        TEXT,
+      paddingLeft     INTEGER NOT NULL DEFAULT 16,
+      paddingTop      INTEGER NOT NULL DEFAULT 16,
+      paddingRight    INTEGER NOT NULL DEFAULT 16,
+      paddingBottom   INTEGER NOT NULL DEFAULT 32,
+      pageAnim        INTEGER NOT NULL DEFAULT 2,
+      titleSize       INTEGER NOT NULL DEFAULT 20,
+      titleAlign      INTEGER NOT NULL DEFAULT 1,
+      indent          INTEGER NOT NULL DEFAULT 2
+    );
+    INSERT OR IGNORE INTO read_config (id, name) VALUES (1, '默认');
+  `);
+}

--- a/src/data/models/RssSource.ts
+++ b/src/data/models/RssSource.ts
@@ -5,28 +5,32 @@ export interface RssSource {
   sourceName: string;
   sourceGroup?: string;
   sourceIcon?: string;
+  sourceComment?: string;
   enabled: boolean;
   enabledCookieJar?: boolean;
+  enableJs?: boolean;
+  loadWithBaseUrl?: boolean;
+  articleStyle?: number; // 0=RSS, 1=WebView
   concurrentRate?: string;
   header?: string;
   loginUrl?: string;
   loginUi?: string;
   loginCheckJs?: string;
   jsLib?: string;
+  injectJs?: string;
+  shouldOverrideUrlLoading?: string;
   sortUrl?: string;
   singleUrl: boolean;
-  articleList?: string;
-  title?: string;
-  author?: string;
-  kind?: string;
-  intro?: string;
-  updateTime?: string;
-  imgUrl?: string;
-  link?: string;
-  content?: string;
+  customOrder?: number;
+  // Rules
+  ruleArticles?: string;
+  ruleNextPage?: string;
+  ruleTitle?: string;
+  rulePubDate?: string;
+  ruleImage?: string;
+  ruleLink?: string;
+  ruleContent?: string;
   style?: string;
-  publishDate?: string;
-  nextPageUrl?: string;
   webCss?: string;
   lastUpdateTime: number;
 }


### PR DESCRIPTION
## 变更内容

### 规则引擎 (T0010–T0016)
- **RuleAnalyzer** — 规则字符串分段，识别 CSS/XPath/JSONPath/JS 前缀，支持 \||\ 候选和 \@\ 多级
- **AnalyzeByCSS** — cheerio CSS 选择器，支持属性提取 (\@href\, \@src\ 等)
- **AnalyzeByXPath** — xpath+xmldom，支持 \@@\ 前缀规则
- **AnalyzeByJSONPath** — jsonpath-plus
- **AnalyzeByRegex** — \##regex##replace\ 规则
- **JSEngine** — Function-based JS eval 沙箱，注入 legado JsExtensions 等价实现
- **AnalyzeRule** — 主入口，串联所有解析器

### 数据库层 (T0003)
- **AppDatabase** — expo-sqlite schema，所有表 + 默认数据
- **BookSourceDao** — 书源 CRUD + 批量导入
- **BookDao** — 书籍 CRUD + 分组过滤 + 进度更新
- **BookChapterDao** — 章节 CRUD + 事务批量写入

Closes #4