### PR TITLE
fix: 精选书源改用 jsDelivr CDN

### DIFF
--- a/src/pages/BookSourceImport.tsx
+++ b/src/pages/BookSourceImport.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { BookSourceImporter } from '@/help/source/BookSourceImporter';
 import { RssSourceImporter } from '@/help/source/RssSourceImporter';
 
-const BASE = 'https://raw.githubusercontent.com/shidahuilang/shuyuan-bak/refs/heads/main/';
+const BASE = 'https://cdn.jsdelivr.net/gh/shidahuilang/shuyuan-bak@main/';
 
 const PRESETS = [
   {


### PR DESCRIPTION
Azure IP被GitHub CDN封锁导致404，改用jsDelivr镜像，已验证三个预设源全部可用。