### PR TITLE
fix: bookList/chapterList use outerHTML not text content

### DIFF
--- a/src/core/network/webBook/BookChapterList.ts
+++ b/src/core/network/webBook/BookChapterList.ts
@@ -58,7 +58,7 @@ function parseToc(
 ): BookChapter[] {
   if (!rule.chapterList) return [];
   const analyzer = new AnalyzeRule(html, baseUrl);
-  const items = analyzer.getStringList(rule.chapterList);
+  const items = analyzer.getElements(rule.chapterList);
 
   return items.map((itemHtml, i) => {
     const a = new AnalyzeRule(itemHtml, baseUrl);

--- a/src/core/network/webBook/BookExplore.ts
+++ b/src/core/network/webBook/BookExplore.ts
@@ -64,7 +64,7 @@ function parseExploreResults(
 ): ExploreItem[] {
   if (!rule.bookList) return [];
   const analyzer = new AnalyzeRule(html, baseUrl);
-  const items = analyzer.getStringList(rule.bookList);
+  const items = analyzer.getElements(rule.bookList);
   if (!items.length) return [];
   return items
     .map(itemHtml => {

--- a/src/core/network/webBook/BookSearch.ts
+++ b/src/core/network/webBook/BookSearch.ts
@@ -55,7 +55,7 @@ function parseSearchResults(
   if (!rule.bookList) return [];
 
   const analyzer = new AnalyzeRule(html, baseUrl);
-  const bookListHtmls = analyzer.getStringList(rule.bookList);
+  const bookListHtmls = analyzer.getElements(rule.bookList);
   if (!bookListHtmls.length) return [];
 
   return bookListHtmls.map((itemHtml) => {

--- a/src/model/analyzeRule/AnalyzeByJSoup.ts
+++ b/src/model/analyzeRule/AnalyzeByJSoup.ts
@@ -74,6 +74,11 @@ export class AnalyzeByCSS {
     return this.getStringFromElement(el, rule);
   }
 
+  /** 获取每个匹配元素的 outerHTML（用于 bookList 等需要继续解析子规则的场景） */
+  getOuterHtmlList(rule: string): string[] {
+    return this.getElements(rule).map(el => this.$.html(el) ?? '');
+  }
+
   /** 获取 HTML 字符串（用于下一级规则） */
   getHtml(rule?: string): string {
     if (!rule) return this.$.html() ?? '';

--- a/src/model/analyzeRule/AnalyzeRule.ts
+++ b/src/model/analyzeRule/AnalyzeRule.ts
@@ -55,6 +55,17 @@ export class AnalyzeRule {
     return [];
   }
 
+  /**
+   * 获取每个匹配元素的 outerHTML 列表
+   * 用于 bookList / exploreList 等"拆分元素后继续解析子规则"的场景
+   */
+  getElements(rule: string): string[] {
+    if (!rule?.trim()) return [];
+    const html = this.toHtml(this.content);
+    const analyzer = new AnalyzeByCSS(html);
+    return analyzer.getOuterHtmlList(rule);
+  }
+
   // ─── 私有实现 ─────────────────────────────────────────────────
 
   private evalCandidate(rule: string): string[] {


### PR DESCRIPTION
Root cause of search/explore returning zero results: CSS element splitting returned text, not HTML markup.