### PR TITLE
feat(rule-engine): legado extended CSS syntax (tag./class./id./!N)

### DIFF
--- a/src/model/analyzeRule/AnalyzeByJSoup.ts
+++ b/src/model/analyzeRule/AnalyzeByJSoup.ts
@@ -1,11 +1,58 @@
 /**
  * AnalyzeByCSS — CSS 选择器解析器
  * 对应 legado Android: AnalyzeByJSoup.kt
- * 使用 cheerio 实现
+ * 使用 cheerio 实现，支持 legado 扩展 CSS 语法：
+ *   class.foo      → .foo
+ *   tag.foo        → foo (tag selector)
+ *   id.foo         → #foo
+ *   tag.td.2       → td elements, take index 2
+ *   class.item!0   → .item elements, exclude index 0
  */
 
 import * as cheerio from 'cheerio';
 import type { AnyNode, Element } from 'domhandler';
+
+/**
+ * 解析 legado 扩展选择器语法
+ * 返回标准 CSS selector + 索引列表 + 排除索引
+ */
+function parseLegadoSelector(rule: string): {
+  selector: string;
+  indices: number[];
+  exclude: number | null;
+} {
+  let r = rule.trim();
+  let exclude: number | null = null;
+
+  // Parse !N suffix (exclusion), e.g. "tag.tr!0" → exclude index 0
+  const excludeMatch = r.match(/!(\d+)$/);
+  if (excludeMatch) {
+    exclude = parseInt(excludeMatch[1]);
+    r = r.slice(0, r.length - excludeMatch[0].length);
+  }
+
+  let selector: string;
+  let indices: number[] = [];
+
+  if (r.startsWith('class.')) {
+    // "class.item" → ".item"; "class.item.2" → ".item" then index 2
+    const parts = r.slice(6).split('.');
+    selector = '.' + parts[0];
+    indices = parts.slice(1).map(Number).filter(n => !isNaN(n));
+  } else if (r.startsWith('tag.')) {
+    // "tag.td" → "td"; "tag.td.2" → "td" then index 2
+    const parts = r.slice(4).split('.');
+    selector = parts[0];
+    indices = parts.slice(1).map(Number).filter(n => !isNaN(n));
+  } else if (r.startsWith('id.')) {
+    selector = '#' + r.slice(3);
+  } else {
+    // Standard CSS (including ":nth-child", ">", etc.)
+    selector = r;
+  }
+
+  return { selector, indices, exclude };
+}
 
 export class AnalyzeByCSS {
   private $: cheerio.CheerioAPI;
@@ -16,18 +63,39 @@ export class AnalyzeByCSS {
     this.root = this.$.root();
   }
 
-  /** 获取元素列表 */
-  getElements(rule: string): cheerio.Cheerio<Element>[] {
+  /**
+   * 获取元素列表（支持 legado 扩展语法）
+   * scope 可指定在哪个父元素内搜索
+   */
+  getElements(rule: string, scope?: cheerio.Cheerio<AnyNode>): cheerio.Cheerio<Element>[] {
     try {
-      const elements = this.root.find(rule);
-      const result: cheerio.Cheerio<Element>[] = [];
-      elements.each((_, el) => {
-        result.push(this.$(el) as cheerio.Cheerio<Element>);
-      });
-      return result;
+      const { selector, indices, exclude } = parseLegadoSelector(rule);
+      const base = scope ?? this.root;
+      const found = base.find(selector);
+
+      let items: Element[] = [];
+      found.each((_, el) => items.push(el));
+
+      // Apply sequential index selection (e.g., tag.td.2 → keep only index 2)
+      for (const idx of indices) {
+        if (idx < items.length) {
+          items = [items[idx]];
+        } else {
+          items = [];
+          break;
+        }
+      }
+
+      // Apply exclusion (e.g., !0 → remove first element)
+      if (exclude !== null) {
+        items = items.filter((_, i) => i !== exclude);
+      }
+
+      return items.map(el => this.$(el) as cheerio.Cheerio<Element>);
     } catch {
       return [];
     }
+  }
   }
 
   /** 按选择器获取单个字符串 */

--- a/src/model/analyzeRule/AnalyzeRule.ts
+++ b/src/model/analyzeRule/AnalyzeRule.ts
@@ -57,13 +57,27 @@ export class AnalyzeRule {
 
   /**
    * 获取每个匹配元素的 outerHTML 列表
-   * 用于 bookList / exploreList 等"拆分元素后继续解析子规则"的场景
+   * 用于 bookList / exploreList / chapterList 等"拆分元素后继续解析子规则"的场景
+   * 支持多级 legado CSS 规则，如 "class.grid@tag.tr!0"
    */
   getElements(rule: string): string[] {
     if (!rule?.trim()) return [];
-    const html = this.toHtml(this.content);
+    const parts = splitByAt(rule);
+    let html = this.toHtml(this.content);
+
+    // Navigate through intermediate levels, narrowing to first matched element's HTML
+    for (let i = 0; i < parts.length - 1; i++) {
+      const analyzer = new AnalyzeByCSS(html);
+      const matched = analyzer.getElements(parts[i]);
+      if (!matched.length) return [];
+      html = analyzer['$'].html(matched[0]) ?? '';
+      if (!html) return [];
+    }
+
+    // Last level: return ALL matched elements as outerHTML
+    const lastPart = parts[parts.length - 1];
     const analyzer = new AnalyzeByCSS(html);
-    return analyzer.getOuterHtmlList(rule);
+    return analyzer.getOuterHtmlList(lastPart);
   }
 
   // ─── 私有实现 ─────────────────────────────────────────────────


### PR DESCRIPTION
Implements legado's JSoup-style selector extensions. Fixes parsing for sources using class.grid, tag.td.2, !0 exclusion etc.